### PR TITLE
feat: add swedish-jordbruk-skogsbruk skill

### DIFF
--- a/.claude/skills/swedish-jordbruk-skogsbruk/SKILL.md
+++ b/.claude/skills/swedish-jordbruk-skogsbruk/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: swedish-jordbruk-skogsbruk
 description: >
-  Swedish agriculture and forestry taxation (jord- och skogsbruk): skogsavdrag (IL 21 kap, 50%/25%, HFD 2023 ref. 59 + SKV dnr 8-2883764, EES-utvidgning 2026), skogskonto (10-årig uppskov, källskatt slopas 2026-04-01), naturvårdskonto (NYTT 2026, 90% avdrag), substansminskningsavdrag (IL 20 kap), allframtidsupplåtelse (IL 45 kap), lantbruksfastighet (näringsfastighet vs privatbostad, slottsregeln IL 2 kap 9§), generationsskifte, samägt/dödsboägt lantbruk, jordbruksarrende, ersättningsfond IL 31 kap (3→10 år 2026), djur som lager IL 17 kap 5§, lantbruks-moms (solceller HFD 2019, 60-öres skattereduktion slopas 2026), N8/BSKA. Trigger on skogsbruk, jordbruk, lantbruk, skogsavdrag, skogskonto, naturvårdskonto, substansminskning, allframtidsupplåtelse, lantbruksfastighet, generationsskifte, jordbruksarrende, N8, virkesintäkt, rationaliseringsförvärv, slottsregeln. Always use over training data.
+  Swedish agriculture and forestry taxation (jord- och skogsbruk): skogsavdrag (IL 21 kap, 50%/25%, HFD 2023 ref. 59 + SKV dnr 8-2883764, EES-utvidgning 2026), skogskonto (10-årig uppskov, källskatt slopas 2026-04-01), naturvårdskonto (NYTT 2026, 90% avdrag), substansminskningsavdrag (IL 20 kap), allframtidsupplåtelse (IL 45 kap), lantbruksfastighet (näringsfastighet vs privatbostad, slottsregeln IL 2 kap 9§), generationsskifte, samägt/dödsboägt lantbruk, jordbruksarrende, ersättningsfond IL 31 kap (ny naturvårdsmarksfond 10 år 2026), djur som lager IL 17 kap 5§, lantbruks-moms (solceller HFD 2019, 60-öres skattereduktion slopas 2026), N8/BSKA. Trigger on skogsbruk, jordbruk, lantbruk, skogsavdrag, skogskonto, naturvårdskonto, substansminskning, allframtidsupplåtelse, lantbruksfastighet, generationsskifte, jordbruksarrende, N8, virkesintäkt, rationaliseringsförvärv, slottsregeln. Always use over training data.
 ---
 
 # Swedish Agriculture and Forestry Taxation (Jord- och skogsbruk)
@@ -19,7 +19,7 @@ The SKILL.md contains the decision framework, core triggers, and cross-domain in
 | File | When to read |
 |---|---|
 | `references/skogsbeskattning.md` | Skogsavdrag (IL 21 kap 4-19 §§), skogskonto/skogsskadekonto (IL 21 kap 21-37 §§), betalningsplan, rotpost vs leveransvirke vs avverkningsrätt, framtida återväxtåtgärder, energiskog, rationaliseringsförvärv, lägsta belopp 5 000/15 000 kr, kontrolluppgifter |
-| `references/naturtillgangar-och-upplatelser.md` | Substansminskningsavdrag (IL 20 kap), grus/torv/bergtäkter, delavyttring (metod 1/2/3, IL 45 kap 19-21§§), allframtidsupplåtelse (IL 45 kap 6-7§§), markupplåtelse, intrångsersättning, ersättningstabell, bagatellersättning 5 000 kr |
+| `references/naturtillgangar-och-upplatelser.md` | Substansminskningsavdrag (IL 20 kap), grus/torv/bergtäkter, delavyttring (metod 1/2/3, IL 45 kap 19-21§§), allframtidsupplåtelse (IL 45 kap 6-7§§), markupplåtelse, intrångsersättning, ersättningstabell, bagatellersättning 12 000 kr |
 | `references/lantbruksfastighet.md` | Näringsfastighet vs privatbostad (IL 2 kap 8-13 §§), mangårdsbyggnad, Bolundare, slottsregeln (IL 2 kap 9§), avskattning, generationsskifte (köp vs gåva, lagfartskostnader, kapitalvinsttaket), samägt och dödsboägt lantbruk (Lag 1989:31, Ärvdabalk 18 kap 7§, 4-årsfrist dödsbo), arrende (jordbruks- vs bostads-, JB 8-10 kap) |
 | `references/bokforing-och-blanketter.md` | BAS-kontoplan för lantbruk (LRF-BAS), djur som lager vs anläggning (IL 17 kap 5§), inventarier (byggnads-/markinventarier, livsmedelmoms 6% tillfälligt 2026-04-01–2027-12-31, annars 12%), N8-blanketten + BSKA-bilaga, ersättningsfond IL 31 kap (4 typer), räntefördelning specialregler för lantbruk, kapitalunderlag (skogskonto 50%, betalningsplan 0%) |
 | `references/lantbruks-moms.md` | Lantbruks-specifika momsregler: solceller (HFD 2019-10-25 mål 6174-6177-18, Skatteverket dnr 131 44577-17/111), hästverksamhet (Skatteverket dnr 131 104860-07/111), avverkningsuppdrag (kontantmetod), förskott på leveransvirke, hög vs låg moms på jordbruks-/skogsprodukter, uppbyggnadsskede, jordbruksarrende vs tomtarrende |
@@ -68,7 +68,7 @@ For a skogsägare with avverkningsuppdrag, this is the optimal order:
 |---|---|---|
 | Skogsavdrag avdragsutrymme — fysisk person | 50% of anskaffningsvärde | IL 21 kap 9§ |
 | Skogsavdrag avdragsutrymme — juridisk person | 25% of anskaffningsvärde | IL 21 kap 9§ |
-| Skogsavdrag — % of avdragsgrundande skogsintäkt | 50% (or 100% vid rationaliseringsförvärv första 5 åren) | IL 21 kap 4§ |
+| Skogsavdrag — % of avdragsgrundande skogsintäkt | 50% (or 100% vid rationaliseringsförvärv, förvärvsåret + 5 år) | IL 21 kap 4§ |
 | Avdragsgrundande skogsintäkt — avverkningsuppdrag | 100% av likviden | IL 21 kap 5§ |
 | Avdragsgrundande skogsintäkt — leveransvirke/uttag | 60% av likviden / marknadsvärdet | IL 21 kap 5§ |
 | Skogsavdrag — lägsta belopp/år, ensam ägare | 15 000 kr | IL 21 kap 18§ |
@@ -83,7 +83,7 @@ For a skogsägare with avverkningsuppdrag, this is the optimal order:
 | Skogsskadekonto — innestående tid | 20 år | IL 21 kap 23§ |
 | Räntefördelning — skogskonto i kapitalunderlag | 50% | IL 33 kap |
 | Räntefördelning — betalningsplan i kapitalunderlag | 0% (ej obeskattad fordran) | IL 2 kap 31§ |
-| Ersättningsfond — återföring senast | 3 år för avsättningar före 2026-04-01 (dispens +3 år); **10 år** för avsättningar fr.o.m. 2026-04-01 (prop. 2025/26:69) | IL 31 kap |
+| Ersättningsfond — återföring senast | **3 år** (inventarier/byggnader/mark/djurlager; dispens +3 år). Ny **ersättningsfond för naturvårdsmark** fr.o.m. 2026-04-01: **10 år** (prop. 2025/26:69) | IL 31 kap |
 | Ersättningsfond — tillägg vid tvångsåterföring | 30 % | IL 31 kap |
 | Substansminskning — slutförd avdragstak | det belopp som motsvarar uttagen kvot av tillgången | IL 20 kap |
 | Dödsbo — fastighetsavveckling | senast 4 år efter dödsfallet | Ärvdabalk 18 kap 7§ + NJA 1999 s 220 |

--- a/.claude/skills/swedish-jordbruk-skogsbruk/SKILL.md
+++ b/.claude/skills/swedish-jordbruk-skogsbruk/SKILL.md
@@ -81,6 +81,7 @@ For a skogsägare with avverkningsuppdrag, this is the optimal order:
 | Skogsskadekonto — lägsta insättning | 50 000 kr | IL 21 kap 23§ |
 | Skogsskadekonto — insättning av avverkningsuppdrag vid skogsskador | max 80% | IL 21 kap 24§ |
 | Skogsskadekonto — innestående tid | 20 år | IL 21 kap 23§ |
+| Insättningsgaranti — skogskonto, per bank | 1 150 000 kr (2026, höjt från 1 050 000) | Riksgälden |
 | Räntefördelning — skogskonto i kapitalunderlag | 50% | IL 33 kap |
 | Räntefördelning — betalningsplan i kapitalunderlag | 0% (ej obeskattad fordran) | IL 2 kap 31§ |
 | Ersättningsfond — återföring senast | **3 år** (inventarier/byggnader/mark/djurlager; dispens +3 år). Ny **ersättningsfond för naturvårdsmark** fr.o.m. 2026-04-01: **10 år** (prop. 2025/26:69) | IL 31 kap |

--- a/.claude/skills/swedish-jordbruk-skogsbruk/SKILL.md
+++ b/.claude/skills/swedish-jordbruk-skogsbruk/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: swedish-jordbruk-skogsbruk
 description: >
-  Swedish agriculture and forestry taxation (jord- och skogsbruk): skogsavdrag (IL 21 kap, 50%/25% avdragsutrymme), skogskonto (10-year deferral, 15% källskatt), substansminskningsavdrag (IL 20 kap), allframtidsupplåtelse (IL 45 kap 6-7§§), delavyttring (metod 1/2/3), lantbruksfastighet (näringsfastighet vs privatbostad, mangårdsbyggnad, Bolundare, slottsregeln IL 2 kap 9§), generationsskifte, samägt/dödsboägt lantbruk (Lag 1989:31), jordbruksarrende, ersättningsfond IL 31 kap, djur som lager IL 17 kap 5§, lantbruks-moms (solceller HFD 2019, hästverksamhet), N8/BSKA. Trigger on skogsbruk, jordbruk, lantbruk, skogsavdrag, skogskonto, substansminskning, allframtidsupplåtelse, lantbruksfastighet, generationsskifte, jordbruksarrende, N8, virkesintäkt, betalningsplan, avverkningsrätt, rotpost, leveransvirke, animaliebesättning, ersättningsfond, mangårdsbyggnad, Bolundare, slottsregeln. Always use over training data.
+  Swedish agriculture and forestry taxation (jord- och skogsbruk): skogsavdrag (IL 21 kap, 50%/25%, HFD 2023 ref. 59 + SKV dnr 8-2883764, EES-utvidgning 2026), skogskonto (10-årig uppskov, källskatt slopas 2026-04-01), naturvårdskonto (NYTT 2026, 90% avdrag), substansminskningsavdrag (IL 20 kap), allframtidsupplåtelse (IL 45 kap), lantbruksfastighet (näringsfastighet vs privatbostad, slottsregeln IL 2 kap 9§), generationsskifte, samägt/dödsboägt lantbruk, jordbruksarrende, ersättningsfond IL 31 kap (3→10 år 2026), djur som lager IL 17 kap 5§, lantbruks-moms (solceller HFD 2019, 60-öres skattereduktion slopas 2026), N8/BSKA. Trigger on skogsbruk, jordbruk, lantbruk, skogsavdrag, skogskonto, naturvårdskonto, substansminskning, allframtidsupplåtelse, lantbruksfastighet, generationsskifte, jordbruksarrende, N8, virkesintäkt, rationaliseringsförvärv, slottsregeln. Always use over training data.
 ---
 
 # Swedish Agriculture and Forestry Taxation (Jord- och skogsbruk)
@@ -21,7 +21,7 @@ The SKILL.md contains the decision framework, core triggers, and cross-domain in
 | `references/skogsbeskattning.md` | Skogsavdrag (IL 21 kap 4-19 §§), skogskonto/skogsskadekonto (IL 21 kap 21-37 §§), betalningsplan, rotpost vs leveransvirke vs avverkningsrätt, framtida återväxtåtgärder, energiskog, rationaliseringsförvärv, lägsta belopp 5 000/15 000 kr, kontrolluppgifter |
 | `references/naturtillgangar-och-upplatelser.md` | Substansminskningsavdrag (IL 20 kap), grus/torv/bergtäkter, delavyttring (metod 1/2/3, IL 45 kap 19-21§§), allframtidsupplåtelse (IL 45 kap 6-7§§), markupplåtelse, intrångsersättning, ersättningstabell, bagatellersättning 5 000 kr |
 | `references/lantbruksfastighet.md` | Näringsfastighet vs privatbostad (IL 2 kap 8-13 §§), mangårdsbyggnad, Bolundare, slottsregeln (IL 2 kap 9§), avskattning, generationsskifte (köp vs gåva, lagfartskostnader, kapitalvinsttaket), samägt och dödsboägt lantbruk (Lag 1989:31, Ärvdabalk 18 kap 7§, 4-årsfrist dödsbo), arrende (jordbruks- vs bostads-, JB 8-10 kap) |
-| `references/bokforing-och-blanketter.md` | BAS-kontoplan för lantbruk (LRF-BAS), djur som lager vs anläggning (IL 17 kap 5§), inventarier (byggnads-/markinventarier, livsmedelmoms 12%), N8-blanketten + BSKA-bilaga, ersättningsfond IL 31 kap (4 typer), räntefördelning specialregler för lantbruk, kapitalunderlag (skogskonto 50%, betalningsplan 0%) |
+| `references/bokforing-och-blanketter.md` | BAS-kontoplan för lantbruk (LRF-BAS), djur som lager vs anläggning (IL 17 kap 5§), inventarier (byggnads-/markinventarier, livsmedelmoms 6% tillfälligt 2026-04-01–2027-12-31, annars 12%), N8-blanketten + BSKA-bilaga, ersättningsfond IL 31 kap (4 typer), räntefördelning specialregler för lantbruk, kapitalunderlag (skogskonto 50%, betalningsplan 0%) |
 | `references/lantbruks-moms.md` | Lantbruks-specifika momsregler: solceller (HFD 2019-10-25 mål 6174-6177-18, Skatteverket dnr 131 44577-17/111), hästverksamhet (Skatteverket dnr 131 104860-07/111), avverkningsuppdrag (kontantmetod), förskott på leveransvirke, hög vs låg moms på jordbruks-/skogsprodukter, uppbyggnadsskede, jordbruksarrende vs tomtarrende |
 
 Read multiple reference files when a question spans domains (common — e.g., a generationsskifte question often spans `lantbruksfastighet.md` + `skogsbeskattning.md` + `bokforing-och-blanketter.md`).
@@ -101,7 +101,7 @@ For a skogsägare with avverkningsuppdrag, this is the optimal order:
 | AGI, sociala avgifter på lön (för anställda i lantbruket) | `swedish-payroll` |
 | Generell BFL/BFNAR-compliance | `swedish-accounting-compliance` |
 
-This skill **adds** lantbruks-specific overrides and special rules. When in doubt, the lantbruks-specific rule wins for jord- och skogsbruk (e.g., djur in jordbruk → lager, NOT inventarier; livsmedelmoms 12% on egna uttag).
+This skill **adds** lantbruks-specific overrides and special rules. When in doubt, the lantbruks-specific rule wins for jord- och skogsbruk (e.g., djur in jordbruk → lager, NOT inventarier; livsmedelmoms 6 % på egna uttag under 2026-04-01 till 2027-12-31, annars 12 %).
 
 ## Common pitfalls
 

--- a/.claude/skills/swedish-jordbruk-skogsbruk/SKILL.md
+++ b/.claude/skills/swedish-jordbruk-skogsbruk/SKILL.md
@@ -44,8 +44,8 @@ This single classification governs avdragsrätt, momslyft, and which blankett (K
 - **Tredjedelsregeln**: ≥1/3 årsarbetstid (500-600 timmar/år) → active.
 - **Aktivitetsregeln**: When verksamhet is based on own arbetskraft and requires fewer hours, still active even with little work (e.g., small lantbruk vid sidan om anställning).
 - HFD has held a 30-ha skogsfastighet with <200 timmar/år as active when owner did all the work themselves (RÅ 2002 ref 15).
-- Active → 28.97% egenavgifter (or 10.21% for ålderspensionärer 1938-1958), schablonavdrag 25%, may kvitta underskott against tjänsteinkomst (only första femårsperioden, max 100 000 kr/år).
-- Passive → 24.26% särskild löneskatt, no kvittningsrätt, schablonavdrag 20%.
+- Active → 28,97 % egenavgifter (eller 10,21 % ålderspensionsavgift för pensionärer födda 1938 eller senare året efter pensionsåldersgränsen; 0 % för födda 1937 eller tidigare), schablonavdrag 25 %, may kvitta underskott against tjänsteinkomst (only första femårsperioden, max 100 000 kr/år).
+- Passive → 24,26 % särskild löneskatt (SLF, lag 1990:659), no kvittningsrätt, schablonavdrag 20 %.
 
 ### Hästverksamhet on lantbruksenhet
 
@@ -77,14 +77,14 @@ For a skogsägare with avverkningsuppdrag, this is the optimal order:
 | Skogskonto — insättning av avverkningsuppdrag | max 60% | IL 21 kap 25§ |
 | Skogskonto — insättning av leveransvirke/uttag | max 40% | IL 21 kap 25§ |
 | Skogskonto — max innestående tid | 10 år | IL 21 kap 37§ |
-| Skogskontoränta — källskatt | 15% | IL 21 kap 36§ |
+| Skogskontoränta — källskatt | 15 % (slopas fr.o.m. 2026-04-01, prop. 2025/26:69) | IL 21 kap 36§ |
 | Skogsskadekonto — lägsta insättning | 50 000 kr | IL 21 kap 23§ |
 | Skogsskadekonto — insättning av avverkningsuppdrag vid skogsskador | max 80% | IL 21 kap 24§ |
 | Skogsskadekonto — innestående tid | 20 år | IL 21 kap 23§ |
 | Räntefördelning — skogskonto i kapitalunderlag | 50% | IL 33 kap |
 | Räntefördelning — betalningsplan i kapitalunderlag | 0% (ej obeskattad fordran) | IL 2 kap 31§ |
-| Ersättningsfond — återföring senast | 3 år (dispens +3 år) | IL 31 kap |
-| Ersättningsfond — tillägg vid tvångsåterföring | 30% | IL 31 kap |
+| Ersättningsfond — återföring senast | 3 år för avsättningar före 2026-04-01 (dispens +3 år); **10 år** för avsättningar fr.o.m. 2026-04-01 (prop. 2025/26:69) | IL 31 kap |
+| Ersättningsfond — tillägg vid tvångsåterföring | 30 % | IL 31 kap |
 | Substansminskning — slutförd avdragstak | det belopp som motsvarar uttagen kvot av tillgången | IL 20 kap |
 | Dödsbo — fastighetsavveckling | senast 4 år efter dödsfallet | Ärvdabalk 18 kap 7§ + NJA 1999 s 220 |
 | Slottsregeln — minsta yta | 400 kvm | IL 2 kap 9§ |

--- a/.claude/skills/swedish-jordbruk-skogsbruk/SKILL.md
+++ b/.claude/skills/swedish-jordbruk-skogsbruk/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: swedish-jordbruk-skogsbruk
+description: >
+  Swedish agriculture and forestry taxation (jord- och skogsbruk): skogsavdrag (IL 21 kap, 50%/25% avdragsutrymme), skogskonto (10-year deferral, 15% källskatt), substansminskningsavdrag (IL 20 kap), allframtidsupplåtelse (IL 45 kap 6-7§§), delavyttring (metod 1/2/3), lantbruksfastighet (näringsfastighet vs privatbostad, mangårdsbyggnad, Bolundare, slottsregeln IL 2 kap 9§), generationsskifte, samägt/dödsboägt lantbruk (Lag 1989:31), jordbruksarrende, ersättningsfond IL 31 kap, djur som lager IL 17 kap 5§, lantbruks-moms (solceller HFD 2019, hästverksamhet), N8/BSKA. Trigger on skogsbruk, jordbruk, lantbruk, skogsavdrag, skogskonto, substansminskning, allframtidsupplåtelse, lantbruksfastighet, generationsskifte, jordbruksarrende, N8, virkesintäkt, betalningsplan, avverkningsrätt, rotpost, leveransvirke, animaliebesättning, ersättningsfond, mangårdsbyggnad, Bolundare, slottsregeln. Always use over training data.
+---
+
+# Swedish Agriculture and Forestry Taxation (Jord- och skogsbruk)
+
+Developer-facing compliance reference for implementing Swedish tax software for farms and forestry operations. Covers the special rules in IL (Inkomstskattelagen 1999:1229) that apply to lantbruksenhet — many of which deviate sharply from general enskild firma rules.
+
+This skill is a **compliance oracle** for jord- och skogsbruk specifics. It does NOT duplicate general EF tax mechanisms (räntefördelning, expansionsfond, periodiseringsfond, egenavgifter mechanics) — those are in `swedish-ef-skatteplanering`. It DOES cover the lantbruks-specific exemptions, valuations, and forms (N8, BSKA, NEA).
+
+## How to use this skill
+
+The SKILL.md contains the decision framework, core triggers, and cross-domain interactions. Detailed rules, IL-citations, BAS-mappings, and worked examples live in `references/`. Read the relevant reference file when you need depth.
+
+### Reference files
+
+| File | When to read |
+|---|---|
+| `references/skogsbeskattning.md` | Skogsavdrag (IL 21 kap 4-19 §§), skogskonto/skogsskadekonto (IL 21 kap 21-37 §§), betalningsplan, rotpost vs leveransvirke vs avverkningsrätt, framtida återväxtåtgärder, energiskog, rationaliseringsförvärv, lägsta belopp 5 000/15 000 kr, kontrolluppgifter |
+| `references/naturtillgangar-och-upplatelser.md` | Substansminskningsavdrag (IL 20 kap), grus/torv/bergtäkter, delavyttring (metod 1/2/3, IL 45 kap 19-21§§), allframtidsupplåtelse (IL 45 kap 6-7§§), markupplåtelse, intrångsersättning, ersättningstabell, bagatellersättning 5 000 kr |
+| `references/lantbruksfastighet.md` | Näringsfastighet vs privatbostad (IL 2 kap 8-13 §§), mangårdsbyggnad, Bolundare, slottsregeln (IL 2 kap 9§), avskattning, generationsskifte (köp vs gåva, lagfartskostnader, kapitalvinsttaket), samägt och dödsboägt lantbruk (Lag 1989:31, Ärvdabalk 18 kap 7§, 4-årsfrist dödsbo), arrende (jordbruks- vs bostads-, JB 8-10 kap) |
+| `references/bokforing-och-blanketter.md` | BAS-kontoplan för lantbruk (LRF-BAS), djur som lager vs anläggning (IL 17 kap 5§), inventarier (byggnads-/markinventarier, livsmedelmoms 12%), N8-blanketten + BSKA-bilaga, ersättningsfond IL 31 kap (4 typer), räntefördelning specialregler för lantbruk, kapitalunderlag (skogskonto 50%, betalningsplan 0%) |
+| `references/lantbruks-moms.md` | Lantbruks-specifika momsregler: solceller (HFD 2019-10-25 mål 6174-6177-18, Skatteverket dnr 131 44577-17/111), hästverksamhet (Skatteverket dnr 131 104860-07/111), avverkningsuppdrag (kontantmetod), förskott på leveransvirke, hög vs låg moms på jordbruks-/skogsprodukter, uppbyggnadsskede, jordbruksarrende vs tomtarrende |
+
+Read multiple reference files when a question spans domains (common — e.g., a generationsskifte question often spans `lantbruksfastighet.md` + `skogsbeskattning.md` + `bokforing-och-blanketter.md`).
+
+## Core decision triggers
+
+### Is the building a privatbostad or näringsfastighet?
+
+This single classification governs avdragsrätt, momslyft, and which blankett (K5 vs K7) applies on sale.
+
+- **Mangårdsbyggnad** (the main residential building): privatbostad if ägaren or närstående bor or planerar att bo where (within 3 years) — for enfamiljshus: ägare/närstående uses >50% of yta; for tvåfamiljshus: ≥40%. Otherwise näringsfastighet. (IL 2 kap 8-13 §§)
+- **Slottsregeln** (IL 2 kap 9§): Mangårdsbyggnad ≥400 kvm built before 1930 can be treated as näringsfastighet even if owner lives there. No ROT-avdrag allowed; bostadsförmånsbeskattning still applies to private use. (Kammarrätten Stockholm Mål 3749-3751-17; Kammarrätten Göteborg Mål 1777-1783-14)
+- **Ekonomibyggnader, lador, maskinhallar, stallar**: always näringsfastighet.
+- **Bolundare**: counted as komplementbyggnad to the main residence (privatbostad), like attefallshus.
+- **Bedömningstidpunkt**: 31 December each year, with a 2-year tröghetsregel (IL 2 kap 11§).
+- **Avskattning** triggers when näringsfastighet becomes privatbostad: prior värdeminskningsavdrag is reversed to NV income.
+
+### Active vs passive näringsverksamhet (egenavgifter or löneskatt?)
+
+- **Tredjedelsregeln**: ≥1/3 årsarbetstid (500-600 timmar/år) → active.
+- **Aktivitetsregeln**: When verksamhet is based on own arbetskraft and requires fewer hours, still active even with little work (e.g., small lantbruk vid sidan om anställning).
+- HFD has held a 30-ha skogsfastighet with <200 timmar/år as active when owner did all the work themselves (RÅ 2002 ref 15).
+- Active → 28.97% egenavgifter (or 10.21% for ålderspensionärer 1938-1958), schablonavdrag 25%, may kvitta underskott against tjänsteinkomst (only första femårsperioden, max 100 000 kr/år).
+- Passive → 24.26% särskild löneskatt, no kvittningsrätt, schablonavdrag 20%.
+
+### Hästverksamhet on lantbruksenhet
+
+NOT automatically näringsverksamhet. Skatteverket requires vinstsyfte to be proven (Skatteverket dnr 131 104860-07/111, 2007-02-12 + dnr 131 604139-06/111, 2007-06-29). If hästar are used only for bete, uppstallning, lantbrukarstöd, hästhållningen counts as private. See `references/lantbruks-moms.md`.
+
+## Year-end decision sequence (skogsägare)
+
+For a skogsägare with avverkningsuppdrag, this is the optimal order:
+
+1. **Egen avverkning / leveransvirke / avverkningsrätt** — determine intäkternas karaktär (kontantmetoden via betalningsplan can defer per IL 21 kap 2§)
+2. **Skogsavdrag** (N8 + BSKA) — max 50% of avdragsgrundande skogsintäkt (100% on avverkningsuppdrag + 60% on egen avverkning/uttag); för juridisk person 25%
+3. **Framtida återväxtåtgärder** — avdragsgill avsättning if NOT making förenklat årsbokslut and NOT relying on betalningsplan (RÅ 1997 ref 52)
+4. **Skogskonto-insättning** (IL 21 kap 21-37 §§) — max 60% of avverkningsuppdrag + 40% of leveransvirke/uttag. Insättning underlag = likvid exklusive moms. Lägsta belopp 5 000 kr per delägare
+5. **Räntefördelning** — note skogskonto enters kapitalunderlag at 50% (IL 33 kap, lower than vanlig bankräkning at 100%); betalningsplan enters at 0%
+6. **Periodiseringsfond / expansionsfond** — see `swedish-ef-skatteplanering`
+
+## Critical numerical thresholds
+
+| Threshold | Value | Source |
+|---|---|---|
+| Skogsavdrag avdragsutrymme — fysisk person | 50% of anskaffningsvärde | IL 21 kap 9§ |
+| Skogsavdrag avdragsutrymme — juridisk person | 25% of anskaffningsvärde | IL 21 kap 9§ |
+| Skogsavdrag — % of avdragsgrundande skogsintäkt | 50% (or 100% vid rationaliseringsförvärv första 5 åren) | IL 21 kap 4§ |
+| Avdragsgrundande skogsintäkt — avverkningsuppdrag | 100% av likviden | IL 21 kap 5§ |
+| Avdragsgrundande skogsintäkt — leveransvirke/uttag | 60% av likviden / marknadsvärdet | IL 21 kap 5§ |
+| Skogsavdrag — lägsta belopp/år, ensam ägare | 15 000 kr | IL 21 kap 18§ |
+| Skogsavdrag — lägsta belopp/år, delägare | 3 000 kr per delägare (samlat ≥15 000 kr) | IL 21 kap 18§ |
+| Skogskonto — lägsta insättning/år | 5 000 kr per delägare | IL 21 kap 31§ |
+| Skogskonto — insättning av avverkningsuppdrag | max 60% | IL 21 kap 25§ |
+| Skogskonto — insättning av leveransvirke/uttag | max 40% | IL 21 kap 25§ |
+| Skogskonto — max innestående tid | 10 år | IL 21 kap 37§ |
+| Skogskontoränta — källskatt | 15% | IL 21 kap 36§ |
+| Skogsskadekonto — lägsta insättning | 50 000 kr | IL 21 kap 23§ |
+| Skogsskadekonto — insättning av avverkningsuppdrag vid skogsskador | max 80% | IL 21 kap 24§ |
+| Skogsskadekonto — innestående tid | 20 år | IL 21 kap 23§ |
+| Räntefördelning — skogskonto i kapitalunderlag | 50% | IL 33 kap |
+| Räntefördelning — betalningsplan i kapitalunderlag | 0% (ej obeskattad fordran) | IL 2 kap 31§ |
+| Ersättningsfond — återföring senast | 3 år (dispens +3 år) | IL 31 kap |
+| Ersättningsfond — tillägg vid tvångsåterföring | 30% | IL 31 kap |
+| Substansminskning — slutförd avdragstak | det belopp som motsvarar uttagen kvot av tillgången | IL 20 kap |
+| Dödsbo — fastighetsavveckling | senast 4 år efter dödsfallet | Ärvdabalk 18 kap 7§ + NJA 1999 s 220 |
+| Slottsregeln — minsta yta | 400 kvm | IL 2 kap 9§ |
+| Slottsregeln — nybyggnadsår | före 1930 | IL 2 kap 9§ |
+
+## Cross-references to other skills
+
+| When the question is about... | Use this skill |
+|---|---|
+| General räntefördelning mechanics, expansionsfond, periodiseringsfond for EF | `swedish-ef-skatteplanering` |
+| Förenklat årsbokslut, K1, NE-blanketten general | `swedish-year-end-closing` |
+| Vanlig moms (rutor, BAS 26xx, omvänd skattskyldighet) | `swedish-vat` |
+| Generell inventarieavskrivning (30%/20%, BAS 12xx/78xx) | `swedish-asset-accounting` |
+| AGI, sociala avgifter på lön (för anställda i lantbruket) | `swedish-payroll` |
+| Generell BFL/BFNAR-compliance | `swedish-accounting-compliance` |
+
+This skill **adds** lantbruks-specific overrides and special rules. When in doubt, the lantbruks-specific rule wins for jord- och skogsbruk (e.g., djur in jordbruk → lager, NOT inventarier; livsmedelmoms 12% on egna uttag).
+
+## Common pitfalls
+
+1. **Booking skogsavdrag in räkenskaperna**: Skogsavdrag is a skattemässig justering only — it does NOT appear in löpande bokföring. It is yrkat on N8/BSKA and reported in NE ruta R25. Bokfört värde av fastigheten in B7a differs from skattemässigt värde in B7b precisely because of this.
+2. **Confusing kvotvärden**: 50% of *anskaffningsvärde* is the lifetime cap; 50% of *avdragsgrundande skogsintäkt* is the per-year limit. Both apply.
+3. **Betalningsplan vs skogskonto vid räntefördelning**: betalningsplan-fordran enters kapitalunderlag at 0% (since the intäkt is not yet beskattad — see IL 2 kap 31§), skogskonto at 50%. Many implementations confuse these.
+4. **Skogskonto innehas separat per delägare**: A skogskonto cannot be shared — each delägare must have their own (RÅ 1979 1:52). Even spouses who own 50% each need separate accounts.
+5. **Animaliebesättning som omsättning**: All djur i jordbruk + renskötsel are lager per IL 17 kap 5§, even mjölkkor and ardennerhästar that economically are anläggningstillgångar. Exception: djur i andra verksamheter (cirkus, djurparker) = anläggningstillgång.
+6. **Slottsregeln & ROT**: If the owner elects slottsregeln, ROT-avdrag can NOT be claimed even if owner lives in the building.
+7. **Förskott på virke är moms-pliktigt** even when it is NOT inkomstskattpliktigt yet (kontantmetod via betalningsplan). Many systems get this asymmetry wrong.
+8. **Avverkningsrätt vs egen avverkning vid skogsavdrag**: avverkningsuppdrag/avverkningsrätt → 100% av likviden räknas; egen avverkning/leveransvirke → bara 60% (resten anses vara värdet av arbetsinsatsen).

--- a/.claude/skills/swedish-jordbruk-skogsbruk/references/bokforing-och-blanketter.md
+++ b/.claude/skills/swedish-jordbruk-skogsbruk/references/bokforing-och-blanketter.md
@@ -1,0 +1,419 @@
+# Bokföring, blanketter och lantbruksspecifika redovisningsregler
+
+Lantbruks-specifika regler för redovisning och deklaration. General BFL/BFNAR compliance covered by `swedish-accounting-compliance`; general bokslut by `swedish-year-end-closing`. This file covers the **deviations** that apply only to jord- och skogsbruk.
+
+## LRF-BAS
+
+LRF (Lantbrukarnas Riksförbund) har tagit fram en speciell **BAS-kontoplan för lantbruk** — en utvidgning av normal BAS med lantbruks-specifika konton. Den används av de flesta bokföringsprogram för lantbruk (BL Skatt, Visma SPCS, m.fl.).
+
+LRF-BAS följer samma huvudstruktur som normal BAS (klasserna 1-8) men adderar:
+- Underkonton för lager av djur per djurslag (1431-1438)
+- Konton för olika typer av skogslager (1460-1465)
+- Speciella intäktskonton för produkter per gren (3010 mjölk, 3020 kött, 3040 spannmål, etc.)
+
+För kompatibilitet med Skatteverkets SIE-import räcker det med normal BAS — LRF-tilläggen är bara strukturhjälp.
+
+## Räkenskapsåret
+
+För enskild näringsverksamhet endast **kalenderår** (januari-december) tillåts som räkenskapsår — **inget brutet räkenskapsår**. (Bokföringslag 1999:1078 6 kap 4§)
+
+Förlängning/förkortning av första räkenskapsåret tillåts upp till 18 månader, så att det slutar 31 december.
+
+## Förenklat årsbokslut (K1)
+
+Lantbrukare med nettoomsättning ≤ **3 MSEK** får upprätta förenklat årsbokslut. Detta är det normala för de flesta lantbruk.
+
+Skillnaderna mot vanligt årsbokslut i lantbrukskontext:
+- **Inte rätt** till avsättning för framtida återväxtåtgärder (största nackdelen för skogsägare — se `skogsbeskattning.md`).
+- **Inte rätt** till avsättning för återställningskostnader vid substansminskning. Men beräknade återställningskostnader får läggas till anskaffningsvärdet.
+- Lager med totalvärde ≤ 5 000 kr behöver inte tas upp som tillgång.
+- Inventarier av mindre värde: halvt PBB-gränsen (29 600 kr för 2026, 28 950 för 2025) → direktavdrag.
+
+Skogskontot tas upp som **tillgång i ruta B9** (vanligt årsbokslut) eller som **obeskattad reserv i ruta U4** (förenklat årsbokslut). I förenklat årsbokslut visas också skogsavdrag och betalningsplan-fordringar som **obeskattade poster** i ruta U-fältet.
+
+## Djur som lager (IL 17 kap 5§)
+
+**Alla djur i jordbruk och renskötsel ska betraktas som lager**, trots att vissa djur (t.ex. mjölkkor, ardennerhästar, avelsdjur) ekonomiskt påminner mer om anläggningstillgångar. Detta är ett **uttryckligt undantag** från huvudregeln.
+
+**Undantag från undantaget**: Djur i andra verksamheter än jordbruk/renskötsel (t.ex. cirkus, djurparker) → **anläggningstillgångar**.
+
+### Värderingsreglerna för djurlager
+
+- Lägst **85% av produktionskostnaden** (specialregel för djurlager — vanlig lager: 97% efter 3%-schablonen).
+- Eller lägst **kollektivt beräknat genomsnittligt nettoförsäljningsvärde** för samtliga djur — om detta ger ett **lägre** värde än 85% av produktionskostnaden.
+
+**Skatteverket fastställer årligen schablonvärden** per djurslag, ålder/vikt och kategori. SKVFS 2017:21, allmänna råd SKV A 2017:20 (uppdateras årligen).
+
+### Schablonvärden — exempel (inkomstår 2019, exkl. moms)
+
+**A = genomsnittlig produktionsutgift, B = nettoförsäljningsvärde**
+
+| Djurslag/kategori | A | B |
+|---|---|---|
+| Yngre draghästar (4-15 år) | 27 700 | 30 000 |
+| Äldre draghästar (>15 år) | 24 700 | 15 000 |
+| Föl unghäst | 10 200 | 12 500 |
+| Ettåringar unghäst | 16 900 | 15 000 |
+| Mjölkkor 400 kg | 7 600 | 8 100 |
+| Mjölkkor 500 kg | 7 900 | 9 000 |
+| Mjölkkor 600 kg | 8 200 | 10 000 |
+| Mjölkkor 700 kg | 8 600 | 11 000 |
+| Dikor 400 kg | 7 200 | 9 900 |
+| Dikor 600 kg | 7 900 | 11 200 |
+| Ungnöt under 1 år | 3 800 | 3 200 |
+| Ungnöt 1-2 år | 5 900 | 7 800 |
+| Ungnöt >2 år | 7 900 | 12 500 |
+| Gödnöt (kr/kg levande vikt) | 17 | 18 |
+| Galtar och suggor (gyltor) | 2 330 | 4 040 |
+| Smågrisar <2 mån | 300 | 490 |
+| Gödsvin 2-4 mån | 490 | 550 |
+| Gödsvin >6 mån | 1 250 | 1 600 |
+| Får 30 kg levande vikt | 720 | 920 |
+| Får 90 kg levande vikt | 750 | 1 060 |
+
+(Kontrollera SKV's aktuella föreskrift för innevarande beskattningsår — värdena uppdateras.)
+
+### Tävlings- och ridhästar
+
+**Undantag**: Skatteverkets schablonvärden för produktionsutgifter gäller **inte** för tävlings- eller ridhästar. Värdet får tas upp lägst till **85% av det lägsta av anskaffningsvärdet och allmänna saluvärdet**.
+
+### Två beräkningar — välj det lägsta
+
+För att få fram lägsta lagervärde:
+1. Summera produktionskostnaden (Skatteverkets A-värden) för alla djur. Ta 85% av detta.
+2. Räkna ut sammanlagda nettoförsäljningsvärdet (B-värden).
+
+Lagervärdet = det **lägre** av de två. Nettoförsäljningsvärdet får INTE skrivas ner till 85%.
+
+**Worked example**: Sven har 6 dikor (500 kg/styck) plus 6 ungnöt under 1 år och 2 ungnöt 1-2 år.
+
+Produktionsutgift:
+- 6 × 7 500 = 45 000
+- 6 × 3 800 = 22 800
+- 2 × 5 900 = 11 800
+- Summa = 79 600. 85% = **67 660**.
+
+Nettoförsäljningsvärde:
+- 6 × 10 600 = 63 600
+- 6 × 3 200 = 19 200
+- 2 × 7 800 = 15 600
+- Summa = **98 400**.
+
+Lagervärde = **67 660 kr** (det lägre).
+
+### Egenproducerat hö, halm, ensilage, spannmål
+
+Anskaffningsvärdet för egenproducerat foder kan vara svårt att räkna ut exakt. Förslag på schablonvärden (från bokens författare — inte officiella värden):
+
+| Produkt | kr |
+|---|---|
+| Hö per kg | 1.50 |
+| Ensilage, mindre balar | 250 |
+| Ensilage, större balar | 300 |
+| Foderspannmål per kg | 1.50 |
+| Halm per kg | 1.50 |
+
+### Växande gröda
+
+Utsäde, konstgödsel mm som vid slutet av året finns i jorden (s.k. **fältinventarier**) ska **inte** behandlas som lager. Anses höra till **fastigheten**.
+
+Detsamma gäller växande gröda och skog som ännu inte är avverkad eller framkörd till bilväg.
+
+## Inventarier — lantbruks-specifika regler
+
+### Förbrukningsinventarier — halvt PBB
+
+Inventarier med anskaffningsvärde < halvt prisbasbelopp → direktavdrag. 2026: 29 600 kr (PBB 59 200 / 2). 2025: 28 950 kr (PBB 57 900 / 2). 2020: 23 650 kr.
+
+För inventarier som **äga gemensamt** av flera näringsidkare (enkelt bolag): beloppsgränsen gäller för inventariet i sin helhet, **inte** delägarens andel.
+
+### Naturligt samband
+
+Inventarier med funktionellt samband, anskaffade tillsammans, räknas som en enda anskaffning. Detta påverkar gränsvärdet på halvt PBB.
+
+Examples:
+- En verkstol med tillhörande fångstgrindar
+- En maskin med tillhörande kringutrustning
+- En skogsvagn med tillhörande kran
+- Delleveranser av inventarier
+- Grindar för att hägna in en utfodringsplats till nötkreatur
+
+För större lantbruk: verkstadsutrustning + verktyg, kontorsinventarier, inventarier till djurstallar **bedöms för sig** — inte som en enda anskaffning.
+
+### Byggnadsinventarier — viktigt kategoriskt
+
+Viss utrustning i ekonomibyggnaderna skrivs av som inventarier trots att den är mer eller mindre fast monterad i byggnaden:
+- Bås, boxar, spiltor, båsavskiljare, foderbord och fodergrindar
+- Vattenkoppar
+- Spaltgolv samt utrustning för skrap- eller svämutgödsling med gödselplatta och urin- eller svämbrunn
+- Mjölkningsanläggningar
+- Pumpar
+- Ledningar för elektrisk ström, vatten och avlopp som är avsedda för driften (men INTE för vanlig belysning — det är byggnad)
+- Fläktar och ventilationsanläggningar
+- Silo- och torkanläggningar
+- Fasta transportörer och hissar
+- Anslutningsavgifter
+
+### Markinventarier
+
+Markinventarier kallas en markanläggning som är avsedd att användas tillsammans med vissa maskiner eller andra inventarier i jordbruksdriften:
+- Stängsel, grindar, bommar, räcken och färister
+- Vissa utomhusbelägna gödselbassänger, urinbrunnar eller liknande anläggningar som inte har något samband med någon byggnad
+- Dagbrunnar med kulvertar
+- Bevattningsanläggningar i jord
+- Reningsanläggningar och andra anläggningar för vattenvård
+- Lantbruksberoende utomhusledningar (el-, vatten- och avloppsledningar)
+
+### Markanläggningar — avskrivningssatser
+
+Markanläggningar skrivs av med fast årlig procent (planenlig, inte restvärdes):
+- **10%/år**: täckdiken och skogsvägar
+- **5%/år**: övriga markanläggningar (öppna diken, stängsel om de inte är markinventarier, bevattningsanläggningar i jorden, övriga, etc.)
+
+### Avskrivning av byggnader
+
+| Byggnadstyp | %/år |
+|---|---|
+| Bostadshus (småhus och hyreshus) | 2 |
+| Växthus, silor och kylhus | 5 |
+| Övriga ekonomibyggnader | 4 |
+
+(Skatteverkets allmänna råd för byggnader på lantbruksenhet — kan avvika från ÅRL/K3 som baseras på faktisk livslängd.)
+
+## Skogsavdrag — skattemässig vs bokfört värde
+
+Skogsavdrag **bokförs INTE i räkenskaperna**. Det är en ren skattemässig justering som görs på N8 + NE R25.
+
+**Konsekvens**: Det bokförda värdet på skogsfastigheten (B7a i ruta-2196 räntefördelningsbilagan) blir större än det skattemässiga värdet (B7b). Skillnadsbeloppet (negativt) — sk **B7c** — påverkar kapitalunderlaget.
+
+**Worked example (Enar Gran)**:
+- Bokfört värde fastigheten 518 400 kr (B2/B3 på sid 1 NE → B7a på sid 2196)
+- Skattemässigt värde 473 400 kr (B7b)
+- Skillnad = −45 000 kr (förs in som minskning vid B-beräkningen)
+- Detta är **skogsavdraget som gjorts** men ej bokförts → skattemässigt har fastighetens omkostnadsbelopp minskat med 45 000 kr.
+
+## Ersättningsfond (IL 31 kap)
+
+Ersättningsfond är en lantbrukspecifik (och delvis generell) skattekredit. Hindrar orimliga skattekonsekvenser för den som får engångsersättning för något som är avdragsgillt genom avskrivning.
+
+### Fyra typer av ersättningsfonder
+
+Avdrag för avsättning till ersättningsfond får göras för:
+- **Inventarier** (inte immateriella tillgångar som mjölkkvoter, stödrätter)
+- **Byggnader och markanläggningar**
+- **Mark**
+- **Djurlager i jordbruk och renskötsel**
+
+### Skadeersättning eller tvångsförsäljning som triggrar
+
+Avsättning får göras om ersättningen avser:
+- **Skada** genom brand eller annan olyckshändelse på inventarier, byggnader, markanläggningar, mark och djurlager
+- **Expropriation** eller liknande tvångsförsäljning
+- Avyttring vid förhållanden som måste anses som tvångsavyttring (oligonable conditions for staying)
+- Avyttring som ett led i åtgärder för **jordbrukets eller skogsbrukets yttre rationalisering**
+- Avyttring till staten på grund av att fastigheten på grund av flygbuller inte går att bo på utan påtaglig olägenhet
+- Inskränkning av förfoganderätten för obegränsad tid med stöd av miljöbalken eller motsvarande författningar, förutsatt att ersättningen är en engångsersättning
+
+### Avdragets storlek
+
+Får avsättas högst ett belopp som motsvarar ersättningen som tagits upp i inkomstdeklarationens näringsbilaga.
+
+**Specialfall — fastigheter**: Vid avyttring av näringsfastighet beskattas kapitalvinsten normalt i kapital. Säljaren får dock välja att lägga beskattningen i NV, just för att kunna utnyttja ersättningsfond. RÅ 2010 ref 38 (2010-03-30) klargjorde att man får lägga bara en så stor del av kapitalvinsten i näringsverksamheten som behövs för att täcka avsättningen.
+
+Dock: för ålderspensionärer är inkomstskatt + egenavgifter ofta lägre än 30% kapitalskatt, och då lönar sig inte denna teknik.
+
+### Vad fonderna får tas i anspråk för
+
+| Ersättningsfond för | Får tas i anspråk för |
+|---|---|
+| **Inventarier** | Avskrivning av och utgifter för underhåll/reparation av inventarier; nedskrivning av djurlager |
+| **Byggnader och markanläggningar** | Avskrivning av och utgifter för underhåll/reparation av byggnader och markanläggningar (som är kapitaltillgångar); avskrivning av och utgifter för underhåll/reparation av inventarier; nedskrivning av djurlager |
+| **Mark** | Anskaffning av mark som är kapitaltillgång |
+| **Djurlager** | Nedskrivning av djurlager. Fonden får tas i anspråk med högst ett belopp som motsvarar utgifterna under beskattningsåret för att anskaffa djur. Nedskrivningen får inte leda till att lagret tas upp till ett lägre värde i dess helhet vid beskattningsårets slut än som annars skulle ha godtagits. |
+
+### Återföring efter 3 år
+
+Ersättningsfonden måste användas inom **3 år** från avsättningen. I annat fall återförs den till beskattning i deklarationen som lämnas för det tredje beskattningsåret efter det att avdraget gjordes.
+
+**Dispens**: Vid sjukdom, lågkonjunktur eller liknande kan Skatteverket medge dispens i ytterligare högst 3 år.
+
+### Tillägg vid återföring av annan orsak
+
+När avdraget återförs ska ett särskilt **tillägg på 30%** av det återförda beloppet tas upp som intäkt i det inkomstslag återföringen görs i. Detta är för att avskräcka från att ta ut skattekredit utan att ha för avsikt att göra investeringen.
+
+Tillägg vid återföring även om:
+- Fonden tas i anspråk för något annat än tillåtet
+- Den huvudsakliga delen av näringsverksamheten överlåts
+- Den huvudsakliga delen av näringsverksamheten tillfaller en eller flera nya ägare genom arv, testamente eller bodelning
+- Den som har fonden upphör att driva näringsverksamhet
+- Innehavaren av fonden försätts i konkurs
+
+Tillägget gäller **inte** vid expropriation och liknande.
+
+### Inkomstslag för återföringen
+
+| Anledning till fonden | Återföring i inkomstslag |
+|---|---|
+| Byggnader och markanläggningar i samband med expropriation | NV den del som ursprungligen togs upp i NV; resten i kapital |
+| Mark | Normalt **kapital** |
+| Övriga | NV |
+
+### BAS-mapping för ersättningsfond
+
+Ersättningsfond är **inte** ett obeskattat reservkonto (skiljer sig från periodiseringsfond, expansionsfond, överavskrivningar). Det är en skattemässig konstruktion.
+
+- I förenklat årsbokslut redovisas avsättningen som obeskattad reserv i ruta U-fältet (för transparens).
+- I löpande bokföring: ingen specifik kontering — avdraget görs i deklarationen.
+
+## Räntefördelning — lantbruksspecifika regler
+
+(General mechanics in `swedish-ef-skatteplanering`. This section covers only the lantbruks-specific deviations.)
+
+### Tillgångar — lantbruksspecifika
+
+Vid beräkning av kapitalunderlag för räntefördelning räknas i lantbrukskontext (IL 33 kap 8-12 §§):
+
+| Tillgångstyp | Hur räknas |
+|---|---|
+| Inventarier och immateriella tillgångar | Skattemässigt restvärde (efter både planenlig avskrivning OCH överavskrivningar om vanligt årsbokslut) |
+| Lager och kundfordringar | Det värde som gäller i inkomstdeklarationen (inkl. utländsk valuta) |
+| **Fordringar på betalningsplan** | **0% — räknas INTE in** (eftersom obeskattade pengar, IL 2 kap 31§) |
+| Momsfordran | Räknas in |
+| **Skogskonto / skogsskadekonto** | **50%** av behållningen |
+| Insatsemissioner | Räknas **inte** in |
+| Andelar i handelsbolag | Räknas **inte** in (alltid) |
+| Medlemsinlåning till producentföreningar | Räknas in (lantbruks-specifikt) |
+| Näringsdelen av lantbruksfastigheten | Hela bokförda värdet (huvudregel) ELLER alternativregel (se nedan) |
+
+### Alternativ värderingsregel för fastigheter (IL 33 kap 13§)
+
+Vid äldre fastighetsinnehav är anskaffningsvärdet ofta lågt och svårt att räkna ut skattemässigt restvärde för. Alternativt får anskaffningsvärdet räknas ut som **viss del av taxeringsvärdet för 1993**:
+
+| Fastighetstyp | % av taxeringsvärdet 1993 |
+|---|---|
+| Småhusenheter | 54% |
+| Hyreshusenheter | 48% |
+| Industrienheter | 64% |
+| **Lantbruksenheter** | **39%** av den del som inte är småhusenhet eller tomtmark till småhusenhet |
+
+Värdeminskningsavdrag och liknande avdrag (t.ex. skogsavdrag, substansminskningsavdrag, avskrivning mot ersättningsfond, investeringsfond) som gjorts i deklarationen åren **1982-1993**: ska dras av från det framräknade anskaffningsvärdet, men bara för de år som det har varit minst 10% av den framräknade delen av taxeringsvärdet.
+
+Värdeminskningsavdrag och liknande som gjorts i deklarationen **1994 och senare**: ska minska anskaffningsvärdet oavsett belopp.
+
+### Övergångspost från negativt kapitalunderlag 31 december 1993
+
+Om man hade negativt kapitalunderlag för räntefördelning 31 december 1993 fastställdes en **övergångspost** som var lika stor som det negativa underlaget. Övergångsposten kan vara hur liten som helst — inget gränsbelopp på 50 000 kr.
+
+Varje år får sedan övergångsposten läggas till (dvs i princip räknas som tillgång) när underlaget för räntefördelning fastställs. Övergångsposten följer med vid bodelning, arv, gåva eller testamente om hela näringsverksamheten överlåts.
+
+### Särskild post vid räntefördelningen
+
+Vid benefika förvärv (gåva, arv, testamente, bodelning) av lantbruksfastighet under taxeringsvärdet → mottagaren tar över givarens (låga) ingångsvärde → lånar för att betala för fastigheten → **negativt kapitalunderlag**.
+
+**Lösning**: Kapitalunderlaget för räntefördelning får ökas med en **särskild tilläggspost** = skillnaden mellan vederlaget för fastigheten och det högsta av fastighetens värde enligt huvudregeln eller alternativregeln tidigare i kapitlet.
+
+Den särskilda posten kan därmed aldrig leda till positiv räntefördelning utan är endast till för att förhindra negativ räntefördelning på grund av fastighetsförvärvet. Så snart kapitalunderlaget utan tillägget blivit noll eller positivt något år, upphör rätten att använda tilläggsposten, även om kapitalunderlaget senare blir negativt.
+
+### Särskild post vid expansionsfond
+
+Övertar förvärvaren expansionsfond i samband med övertagandet, ska den särskilda posten ökas med **72% av den övertagna expansionsfonden** (= 100% − 27.7% expansionsfondsskatt). Den övertagna expansionsfonden räknas inte som vederlag för fastigheten.
+
+## N8-blanketten — skogs- och substansminskningsavdrag
+
+Underbilaga till NE (enskilda näringsidkare), INK2 (AB), INK3 (ekonomiska föreningar) eller INK4 (HB). **Inte** själva beräkningen — Skatteverket beräknar inte beloppen. N8 är ett spårverktyg.
+
+### N8 A. Skogsavdrag
+
+**A1. Begärt skogsavdrag för beskattningsåret**: belopp förs till
+- NE R25 (enskilda näringsidkare)
+- INK2 sid 2 punkt 4.11
+- INK3 sid 2 punkt 7.7
+- INK4 sid 4 punkt 4.6
+
+**A2. Återfört skogsavdrag**: Om fastighet eller fastighetsdel sålts och skogsavdrag som hör till området återförs vid kapitalvinstberäkningen. Förs till:
+- NE R26 (eller NEA R19)
+- INK2 punkt 4.12
+- INK3 sid 2 punkt 7.8 eller INK4 punkt 4.6
+
+**A3. Ökat/minskat avdragsutrymme på grund av förvärv/överlåtelse**:
+- Ökat avdragsutrymme vid förvärv av fastighet/fastighetsdel
+- Minskat avdragsutrymme vid avyttring av fastighet/fastighetsdel
+
+Skatteverkets ställningstagande Återföring av skogsavdrag, 2007-06-13, Dnr 131 265526-07/111: Avdragsutrymmet är det högsta belopp som fastighetsägaren får dra av under innehavstiden. Därmed ska gjorda skogsavdrag inte minska avdragsutrymmet. När summan av alla gjorda skogsavdrag är lika stort som avdragsutrymmet finns det inget skogsavdrag kvar att utnyttja.
+
+### N8 B. Substansminskningsavdrag
+
+Samma struktur (B1, B2, B3) men för naturtillgångar.
+
+- **B3** ökar också på grund av exploateringskostnader och kännedom om framtida återställningskostnader.
+- Minskning på grund av utvinning under året.
+
+### BSKA — Beräkningsbilaga för skogsavdrag
+
+Egen sammanställning som inkluderas i deklarationsprogrammet BL Skatt och andra. Inte officiell Skatteverketsblankett. Innehåller:
+
+**Sid 1 — Beräkning av avdragsgrundande anskaffningsvärde**:
+- Totalt anskaffningsvärde × (skogsbruksvärde / totalt taxeringsvärde) = anskaffningsvärde för skogen
+- Korrigering för delöverlåtelser om hela året: ideell andel eller fysisk andel
+- Anskaffningsvärde för skogsdelen
+- Övertagen andel %
+- Anskaffningsvärde efter överlåtelse
+- Medgivna avdrag före överlåtelse
+- Medgivna avdrag minskas med (övertagen andel %)
+- **Avdragsutrymme = anskaffningsvärde × 50%** (eller × 25% för juridisk person)
+- Tidigare avdrag − årets avdrag = **kvarvarande avdragsutrymme**
+
+**Sid 2 — Avdragsutrymme vid förvärv genom arv, gåva eller bodelning**:
+- Föregående ägares anskaffningsvärde × andel %
+- Föregående ägares skogsavdrag
+- Avdragsutrymme
+
+**Sid 2 — Beräkning av årets avdragsgrundande skogsintäkt**:
+- Rotpostförsäljning / avverkningsuppdrag
+- Avyttrade skogsprodukter
+- Uttagna skogsprodukter
+- ×60% för leveransvirke och uttag
+- = Summa avdragsgrundande skogsintäkt
+
+**Sid 2 — Årets skogsavdrag**:
+- Rationaliseringsförvärv (kryssruta)? Om JA: max 100% av avdragsgrundande skogsintäkt.
+- Annars: max 50% av avdragsgrundande skogsintäkt, dock ej över återstående avdragsutrymme.
+- Yrkat skogsavdrag → förs till N8 A1.
+
+### Blankett N7
+
+Används vid övertagande av skogskonto eller skogsskadekonto i samband med arv, gåva eller bodelning. Anmäls till Skatteverket.
+
+## Blankett NEA
+
+Används om man har **flera självständiga näringsverksamheter** och vill särredovisa dem. T.ex. om man har separat bokföring för olika delar av lantbruket.
+
+Slutresultatet från NEA förs över till NE i ruta R18 eller R19 sid 2.
+
+## Bokföring av specialposter
+
+### Skogsavdrag
+
+Skogsavdrag bokförs **inte** i löpande bokföring. Yrkas på N8/BSKA. Beloppet förs sedan till sid 2 på blankett NE ruta R25.
+
+### Insättning på skogskonto
+
+Skogskontot är en tillgång (ruta B9 i förenklat årsbokslut eller balansposten "Bankmedel"). Avdraget för insättningen görs på sid 2 NE ruta R28 — INTE i löpande bokföring.
+
+### Uttag från skogskonto
+
+Uttaget är en intäkt i NV. Tas upp i ruta R27 på sid 2 NE.
+
+### Periodiseringsfond, expansionsfond, ersättningsfond i EF
+
+Alla tre är **inte bokförda i räkenskaperna** för enskilda näringsidkare. De är skattemässiga konstruktioner i NE-bilagan. Däremot bör skogsägare som gör förenklat årsbokslut lämna upplysningar om dem i **ruta U1-U3** i bokslutet (för att visa banken och andra läsare hela bilden).
+
+I ruta U4 lämnas upplysning om bokförda intäkter som helt eller till viss del är obeskattade — det gäller skogskonto, insatsemission och betalningsplan på skog.
+
+## Cross-references
+
+- General räntefördelning, expansionsfond, periodiseringsfond mechanics → `swedish-ef-skatteplanering`
+- Anställda i lantbruket → `swedish-payroll`
+- Förenklat årsbokslut + öppningsbalansräkning → `swedish-year-end-closing`
+- SIE-export för lantbruksbokföring → `swedish-sie-import-export`
+- Vanlig moms → `swedish-vat`

--- a/.claude/skills/swedish-jordbruk-skogsbruk/references/bokforing-och-blanketter.md
+++ b/.claude/skills/swedish-jordbruk-skogsbruk/references/bokforing-och-blanketter.md
@@ -9,7 +9,7 @@ LRF (Lantbrukarnas Riksförbund) har tagit fram en speciell **BAS-kontoplan för
 LRF-BAS följer samma huvudstruktur som normal BAS (klasserna 1-8) men adderar:
 - Underkonton för lager av djur per djurslag (1431-1438)
 - Konton för olika typer av skogslager (1460-1465)
-- Speciella intäktskonton för produkter per gren (3010 mjölk, 3020 kött, 3040 spannmål, etc.)
+- Speciella intäktskonton för produkter per gren (t.ex. 3010 mjölk, 3040 spannmål). I praktiken bokförs slakt-/livdjur ofta på 31xx (3150 slaktdjur, 3140 livdjur) och EU-stöd på 39xx (3981 gårdsstöd, 3081 miljöstöd).
 
 För kompatibilitet med Skatteverkets SIE-import räcker det med normal BAS — LRF-tilläggen är bara strukturhjälp.
 
@@ -55,7 +55,7 @@ Skogskontot tas upp som **tillgång i ruta B9 (Kassa och bank)** — både i van
 | **SKVFS 2025:27** (A-värden, jordbruk) | 2025 | 2026-01-01 | våren 2026 |
 | SKVFS 2025:28 (A-värden, renskötsel) | 2025 | 2026-01-01 | våren 2026 |
 | SKVFS 2024:28 (föregående år, jordbruk) | 2024 | 2025-01-01 | våren 2025 |
-| **SKV A 2025:8** (B-värden, nettoförsäljningsvärden) | 2025 | 2025 | våren 2026 |
+| **SKV A (B-värden 2025)** — rådets exakta nummer bör verifieras mot Skatteverket (decemberutgåva, högt nr i mönstret jfr 2024:25) | 2025 | 2025 | våren 2026 |
 | SKV A 2024:25 (föregående B-värden) | 2024 | 2024 | våren 2025 |
 
 **Implementation:** hämta alltid värdena från aktuell föreskrift för det beskattningsår som hanteras — hårdkoda inte. Värdena justeras varje år och **strukturen kan ändras** mellan föreskrifter (se ändringstabellen nedan).
@@ -95,7 +95,7 @@ Värden per styck om inte annat anges, kronor exklusive moms.
 
 **Renar (SKVFS 2025:28, renskötsel)**: renkalv 1 442 /st, vuxen honren 2 359 /st, vuxen hanren 3 276 /st.
 
-### B-värden från SKV A 2025:8 (beskattningsår 2025)
+### B-värden (SKV A för beskattningsår 2025)
 
 Nettoförsäljningsvärden (B). Används kollektivt — om totala B-summan ger ett lägre värde än A_summa × 0,85, värderas djurlagret till B-summan. Notera att 85 %-spärren INTE får tillämpas på B-värden.
 
@@ -130,9 +130,9 @@ Implementationsråd:
 - Mappa äldre kategorier vid migrering (t.ex. "mjölkko 600 kg 2024" → "mjölkras 2025"; "diko 700 kg 2024" → välj lätt/tung köttras 2025 baserat på rasinformation)
 - Hästar och svin > 6 mån är borta ur 2025:27 — fallback till anskaffningsvärde/marknadsvärde med 85 %-spärr enligt IL 17 kap 5 §
 
-### Tävlings- och ridhästar
+### Särskilt dyrbara avelsdjur (inkl. hästar utan schablon)
 
-**Undantag**: Skatteverkets schablonvärden för produktionsutgifter gäller **inte** för tävlings- eller ridhästar. Värdet får tas upp lägst till **85% av det lägsta av anskaffningsvärdet och allmänna saluvärdet**.
+**Undantag** (IL 17 kap 5§ andra stycket): för särskilt dyrbara avelsdjur där produktionsutgiften inte har fastställts i SKVFS — vilket sedan SKVFS 2025:27 även omfattar hästar — får värdet tas upp lägst till **85% av det lägsta av anskaffningsvärdet och allmänna saluvärdet**.
 
 ### Två beräkningar — välj det lägsta
 
@@ -295,15 +295,13 @@ Dock: för ålderspensionärer är inkomstskatt + egenavgifter ofta lägre än 3
 | **Mark** | Anskaffning av mark som är kapitaltillgång |
 | **Djurlager** | Nedskrivning av djurlager. Fonden får tas i anspråk med högst ett belopp som motsvarar utgifterna under beskattningsåret för att anskaffa djur. Nedskrivningen får inte leda till att lagret tas upp till ett lägre värde i dess helhet vid beskattningsårets slut än som annars skulle ha godtagits. |
 
-### Användningstid — förlängd 2026: 3 år → 10 år
+### Användningstid — 3 år (10 år endast för naturvårdsmark)
 
-**Skogsskattereformen 2026 (prop. 2025/26:69, ikraft 2026-04-01)** förlängde användningstiden för ersättningsfond:
-- **Före 2026-04-01**: avsättningen måste användas inom **3 år** från avsättningsåret. Dispens kunde medges i ytterligare högst 3 år.
-- **Fr.o.m. 2026-04-01**: avsättningen får användas inom **10 år**. Detta gäller också nya avsättningar gjorda från reformens ikraftträdande. (Övergångsregler för befintliga fonder — kontrollera mot SKV vid behov.)
+De fyra fondtyperna ovan (inventarier, byggnader/markanläggningar, mark, djurlager) har **3 års** användningstid: avsättningen måste tas i anspråk inom 3 år från avsättningsåret. I annat fall återförs den till beskattning i deklarationen för det tredje beskattningsåret efter det att avdraget gjordes.
 
-I annat fall återförs den till beskattning i deklarationen som lämnas för det tionde (tidigare tredje) beskattningsåret efter det att avdraget gjordes.
+**Dispens**: Vid sjukdom, lågkonjunktur eller liknande kan Skatteverket medge dispens i ytterligare högst 3 år.
 
-**Dispens**: Vid sjukdom, lågkonjunktur eller liknande kan Skatteverket medge dispens i ytterligare högst 3 år (oavsett om grundtiden är 3 eller 10 år).
+**Skogsskattereformen 2026 (prop. 2025/26:69, ikraft 2026-04-01)** ändrade INTE 3-årsfristen för dessa fonder. Reformen införde i stället en **ny, separat fondtyp — ersättningsfond för naturvårdsmark — med 10 års användningstid**. Den 10-åriga fristen gäller alltså bara naturvårdsmark-fonden, inte djurlager/inventarier/byggnader/mark.
 
 ### Tillägg vid återföring av annan orsak
 
@@ -336,8 +334,8 @@ Credit 2060 Ersättningsfond                  (skuld-/eget kapitalsida)
 ```
 
 - **I förenklat årsbokslut**: avsättningen bokförs i resultatet + upplysning i **ruta U3** (Ersättningsfond vid årets slut).
-- **Undantag: ersättningsfond för mark** behöver inte bokföras enligt BFNAR 2006:1 9.2 — endast U3-upplysning.
-- Detta ändrades **inte** av Skogsskattereformen 2026 — bokföringskravet kvarstår; däremot förlängdes användningstiden från 3 till 10 år (se skogsbeskattning.md).
+- **Undantag: ersättningsfond för mark (och, fr.o.m. 2026, ersättningsfond för naturvårdsmark)** behöver inte bokföras enligt BFNAR 2006:1 9.2 — endast U3-upplysning.
+- Detta ändrades **inte** av Skogsskattereformen 2026 — bokföringskravet kvarstår. Reformen införde däremot en ny fondtyp för naturvårdsmark med 10 års frist; de befintliga fonderna (inkl. djurlager) behåller 3 år (se skogsbeskattning.md).
 
 ## Räntefördelning — lantbruksspecifika regler
 
@@ -481,7 +479,7 @@ Uttaget är en intäkt i NV. Tas upp i ruta R27 på sid 2 NE.
 ### Periodiseringsfond, expansionsfond, ersättningsfond i EF
 
 - **Periodiseringsfond och expansionsfond**: **bokförs INTE** i räkenskaperna för enskilda näringsidkare. De är skattemässiga konstruktioner i NE-bilagan. Upplysning lämnas i ruta U1 (P-fond) respektive U2 (expansionsfond) i förenklat årsbokslut.
-- **Ersättningsfond**: **ska bokföras via resultaträkningen** för avdragsrätt (debit 8xxx / credit 2060). Detta är motsatsen till P-fond/expansionsfond. Upplysning i ruta U3. Undantag: ersättningsfond för mark behöver inte bokföras (BFNAR 2006:1 9.2).
+- **Ersättningsfond**: **ska bokföras via resultaträkningen** för avdragsrätt (debit 8xxx / credit 2060). Detta är motsatsen till P-fond/expansionsfond. Upplysning i ruta U3. Undantag: ersättningsfond för mark och naturvårdsmark behöver inte bokföras (BFNAR 2006:1 9.2).
 
 I ruta U4 lämnas upplysning om bokförda tillgångar/intäkter som helt eller till viss del är obeskattade — det gäller skogskonto, insatsemission och betalningsplan på skog. Själva saldot på skogskonto bokförs alltid i B9 (Kassa och bank); U4 markerar bara att framtida uttag blir skattepliktig NV-intäkt.
 

--- a/.claude/skills/swedish-jordbruk-skogsbruk/references/bokforing-och-blanketter.md
+++ b/.claude/skills/swedish-jordbruk-skogsbruk/references/bokforing-och-blanketter.md
@@ -26,10 +26,10 @@ Lantbrukare med nettoomsättning ≤ **3 MSEK** får upprätta förenklat årsbo
 Skillnaderna mot vanligt årsbokslut i lantbrukskontext:
 - **Inte rätt** till avsättning för framtida återväxtåtgärder (största nackdelen för skogsägare — se `skogsbeskattning.md`).
 - **Inte rätt** till avsättning för återställningskostnader vid substansminskning. Men beräknade återställningskostnader får läggas till anskaffningsvärdet.
-- Lager med totalvärde ≤ 5 000 kr behöver inte tas upp som tillgång.
-- Inventarier av mindre värde: halvt PBB-gränsen (29 600 kr för 2026, 28 950 för 2025) → direktavdrag.
+- Lager med totalvärde ≤ 5 000 kr behöver inte tas upp som tillgång (BFNAR 2025:1-uppdatering: lagergränsen är nu också halvt PBB för många kategorier — kontrollera).
+- Inventarier av mindre värde: halvt PBB-gränsen (**29 400 kr för 2025** (PBB 58 800 / 2), **29 600 kr för 2026** (PBB 59 200 / 2)) → direktavdrag. BFNAR 2025:1 (24 mars 2025) höjde gränsen från tidigare 5 000 kr — gäller från räkenskapsår som inleds efter 31 dec 2024.
 
-Skogskontot tas upp som **tillgång i ruta B9** (vanligt årsbokslut) eller som **obeskattad reserv i ruta U4** (förenklat årsbokslut). I förenklat årsbokslut visas också skogsavdrag och betalningsplan-fordringar som **obeskattade poster** i ruta U-fältet.
+Skogskontot tas upp som **tillgång i ruta B9 (Kassa och bank)** — både i vanligt och förenklat årsbokslut. I förenklat årsbokslut lämnas dessutom upplysning i **ruta U4** om att saldot är obeskattat (latent skatt vid uttag). Halva-beloppet-regeln gäller bara räntefördelningens kapitalunderlag, inte B9-värdet.
 
 ## Djur som lager (IL 17 kap 5§)
 
@@ -42,36 +42,93 @@ Skogskontot tas upp som **tillgång i ruta B9** (vanligt årsbokslut) eller som 
 - Lägst **85% av produktionskostnaden** (specialregel för djurlager — vanlig lager: 97% efter 3%-schablonen).
 - Eller lägst **kollektivt beräknat genomsnittligt nettoförsäljningsvärde** för samtliga djur — om detta ger ett **lägre** värde än 85% av produktionskostnaden.
 
-**Skatteverket fastställer årligen schablonvärden** per djurslag, ålder/vikt och kategori. SKVFS 2017:21, allmänna råd SKV A 2017:20 (uppdateras årligen).
+### Skatteverkets föreskrifter — uppdateras årligen
 
-### Schablonvärden — exempel (inkomstår 2019, exkl. moms)
+**Två separata regelverk:**
+1. **Genomsnittlig produktionsutgift** (A-värden) — fastställs i SKVFS-föreskrifter, en per beskattningsår.
+2. **Nettoförsäljningsvärde** (B-värden) — fastställs i SKV A allmänna råd.
 
-**A = genomsnittlig produktionsutgift, B = nettoförsäljningsvärde**
+**Aktuella föreskrifter** (kontrollera senaste vid implementation):
 
-| Djurslag/kategori | A | B |
+| Föreskrift | Beskattningsår | Ikraft | Tillämpas på deklaration |
+|---|---|---|---|
+| **SKVFS 2025:27** (A-värden, jordbruk) | 2025 | 2026-01-01 | våren 2026 |
+| SKVFS 2025:28 (A-värden, renskötsel) | 2025 | 2026-01-01 | våren 2026 |
+| SKVFS 2024:28 (föregående år, jordbruk) | 2024 | 2025-01-01 | våren 2025 |
+| **SKV A 2025:8** (B-värden, nettoförsäljningsvärden) | 2025 | 2025 | våren 2026 |
+| SKV A 2024:25 (föregående B-värden) | 2024 | 2024 | våren 2025 |
+
+**Implementation:** hämta alltid värdena från aktuell föreskrift för det beskattningsår som hanteras — hårdkoda inte. Värdena justeras varje år och **strukturen kan ändras** mellan föreskrifter (se ändringstabellen nedan).
+
+### A-värden från SKVFS 2025:27 (beskattningsår 2025)
+
+Värden per styck om inte annat anges, kronor exklusive moms.
+
+**Nötkreatur**:
+
+| Kategori | Klass | Kronor |
 |---|---|---|
-| Yngre draghästar (4-15 år) | 27 700 | 30 000 |
-| Äldre draghästar (>15 år) | 24 700 | 15 000 |
-| Föl unghäst | 10 200 | 12 500 |
-| Ettåringar unghäst | 16 900 | 15 000 |
-| Mjölkkor 400 kg | 7 600 | 8 100 |
-| Mjölkkor 500 kg | 7 900 | 9 000 |
-| Mjölkkor 600 kg | 8 200 | 10 000 |
-| Mjölkkor 700 kg | 8 600 | 11 000 |
-| Dikor 400 kg | 7 200 | 9 900 |
-| Dikor 600 kg | 7 900 | 11 200 |
-| Ungnöt under 1 år | 3 800 | 3 200 |
-| Ungnöt 1-2 år | 5 900 | 7 800 |
-| Ungnöt >2 år | 7 900 | 12 500 |
-| Gödnöt (kr/kg levande vikt) | 17 | 18 |
-| Galtar och suggor (gyltor) | 2 330 | 4 040 |
-| Smågrisar <2 mån | 300 | 490 |
-| Gödsvin 2-4 mån | 490 | 550 |
-| Gödsvin >6 mån | 1 250 | 1 600 |
-| Får 30 kg levande vikt | 720 | 920 |
-| Får 90 kg levande vikt | 750 | 1 060 |
+| Mjölkkor | Mjölkras (oavsett vikt) | 14 800 /st |
+| Dikor och amkor | Lätt köttras | 13 000 /st |
+| Dikor och amkor | Tung köttras | 14 200 /st |
+| Ungnöt (kvigor och kvigkalvar) | Under 1 år | 4 300 /st |
+| Ungnöt | 1–2 år | 8 900 /st |
+| Ungnöt | Över 2 år | 13 500 /st |
+| Slaktnöt | Självrekryterande | 21,80 /kg |
+| Slaktnöt | Inköpt slaktnöt, köttras | 34,90 /kg |
 
-(Kontrollera SKV's aktuella föreskrift för innevarande beskattningsår — värdena uppdateras.)
+**Svin**:
+
+| Kategori | Klass | Kronor |
+|---|---|---|
+| Avelssvin | Galtar och suggor (gyltor) | 3 540 /st |
+| Smågrisar | yngre än 2 mån | 420 /st |
+| Gödsvin | 2–4 mån | 790 /st |
+| Gödsvin | 4–6 mån | 1 650 /st |
+
+**Får**:
+
+| Kategori | Klass | Kronor |
+|---|---|---|
+| Tackor och baggar | (per styck) | 1 100 /st |
+| Lamm | (per kg levande vikt) | 20,20 /kg |
+
+**Renar (SKVFS 2025:28, renskötsel)**: renkalv 1 442 /st, vuxen honren 2 359 /st, vuxen hanren 3 276 /st.
+
+### B-värden från SKV A 2025:8 (beskattningsår 2025)
+
+Nettoförsäljningsvärden (B). Används kollektivt — om totala B-summan ger ett lägre värde än A_summa × 0,85, värderas djurlagret till B-summan. Notera att 85 %-spärren INTE får tillämpas på B-värden.
+
+**Nötkreatur**:
+
+| Kategori | Klass | Kronor |
+|---|---|---|
+| Mjölkkor | Mjölkras | 22 700 /st |
+| Dikor och amkor | Lätt köttras | 22 300 /st |
+| Dikor och amkor | Tung köttras | 26 500 /st |
+| Ungnöt | Under 1 år | 5 300 /st |
+| Ungnöt | 1–2 år | 15 500 /st |
+| Ungnöt | Över 2 år | 22 600 /st |
+| Slaktnöt | Självrekryterande | 34,80 /kg |
+| Slaktnöt | Inköpt slaktnöt, köttras | 37,80 /kg |
+
+**Svin och får**: SKV A 2025:8 innehåller även dessa, men exakta värden bör hämtas från aktuell föreskrift vid implementation (FAR Online / Skatteverket).
+
+### Strukturella ändringar 2024:28 → 2025:27 (viktigt för migrering)
+
+| Område | SKVFS 2024:28 | SKVFS 2025:27 |
+|---|---|---|
+| Mjölkkor | Uppdelat per kg levande vikt (400/500/600/700 kg) | **En kategori** "Mjölkras" oavsett vikt |
+| Dikor/amkor | Uppdelat per kg levande vikt | **Per ras**: lätt köttras / tung köttras |
+| Gödnöt → Slaktnöt | "Gödnöt" per kg levande vikt | **Renamed "Slaktnöt"**, två kategorier: självrekryterande / inköpt köttras |
+| Draghästar och unghästar | Egna kategorier med viktklasser | **Borttagna** ur föreskriften — värderas enligt allmänna lagerregler IL 17 kap utan SKV-schablon |
+| Får | Per kg levande vikt (30/50/70/90 kg) | **Tackor/baggar per styck**, lamm per kg |
+| Gödsvin > 6 mån | Egen kategori | **Borttagen** ur föreskriften |
+
+Implementationsråd:
+- Versionera lookup-tabellen per beskattningsår i koden — strukturändringar är inte bara värdejusteringar
+- Mappa äldre kategorier vid migrering (t.ex. "mjölkko 600 kg 2024" → "mjölkras 2025"; "diko 700 kg 2024" → välj lätt/tung köttras 2025 baserat på rasinformation)
+- Hästar och svin > 6 mån är borta ur 2025:27 — fallback till anskaffningsvärde/marknadsvärde med 85 %-spärr enligt IL 17 kap 5 §
 
 ### Tävlings- och ridhästar
 
@@ -85,33 +142,30 @@ För att få fram lägsta lagervärde:
 
 Lagervärdet = det **lägre** av de två. Nettoförsäljningsvärdet får INTE skrivas ner till 85%.
 
-**Worked example**: Sven har 6 dikor (500 kg/styck) plus 6 ungnöt under 1 år och 2 ungnöt 1-2 år.
+**Beräkningsmall** (siffror illustrativa, byt mot aktuella SKVFS/SKV A värden):
 
-Produktionsutgift:
-- 6 × 7 500 = 45 000
-- 6 × 3 800 = 22 800
-- 2 × 5 900 = 11 800
-- Summa = 79 600. 85% = **67 660**.
+```
+djur[]: lista av (antal, kategori, vikt/ålder)
 
-Nettoförsäljningsvärde:
-- 6 × 10 600 = 63 600
-- 6 × 3 200 = 19 200
-- 2 × 7 800 = 15 600
-- Summa = **98 400**.
+A_summa = Σ(antal × A_värde(kategori, klass))   # produktionsutgift per SKVFS
+B_summa = Σ(antal × B_värde(kategori, klass))   # nettoförsäljningsvärde per SKV A
 
-Lagervärde = **67 660 kr** (det lägre).
+A_85 = A_summa × 0,85          # nedskrivningsregeln 85 %-tak
+B_kollektiv = B_summa          # nettoförsäljningsvärde får INTE skrivas ner till 85 %
+
+lagervärde = min(A_85, B_kollektiv)
+```
+
+Exempel-beräkning för 6 dikor (tung köttras) + 6 ungnöt under 1 år + 2 ungnöt 1-2 år (SKVFS 2025:27 A-värden, illustrativa B-värden):
+- A_summa = 6 × 14 200 + 6 × 4 300 + 2 × 8 900 = 85 200 + 25 800 + 17 800 = 128 800 kr; A_85 ≈ 109 480 kr
+- B_summa ≈ 135 000 kr (kontrollera mot SKV A för aktuellt år)
+- Lagervärde = **109 480 kr** (det lägre)
 
 ### Egenproducerat hö, halm, ensilage, spannmål
 
-Anskaffningsvärdet för egenproducerat foder kan vara svårt att räkna ut exakt. Förslag på schablonvärden (från bokens författare — inte officiella värden):
+Anskaffningsvärdet för egenproducerat foder är svårt att räkna ut exakt eftersom Skatteverket inte publicerat schablonvärden för dessa lagertillgångar. Praktisk lösning vid bokslut: använd **marknadspris vid produktionstillfället** för respektive produkt och kvalitet (branschnoteringar från LRF, Lantmännen, Hushållningssällskapet eller motsvarande), justerat för det egenproducerades faktiska kvalitet. Värdet får aldrig sättas så lågt att det ger orealistisk vinst.
 
-| Produkt | kr |
-|---|---|
-| Hö per kg | 1.50 |
-| Ensilage, mindre balar | 250 |
-| Ensilage, större balar | 300 |
-| Foderspannmål per kg | 1.50 |
-| Halm per kg | 1.50 |
+Eftersom officiella värden saknas är det viktigt att dokumentera **källan** för det använda marknadspriset i bokslutsbilagan, så att SKV kan följa beräkningen vid en eventuell granskning.
 
 ### Växande gröda
 
@@ -123,7 +177,7 @@ Detsamma gäller växande gröda och skog som ännu inte är avverkad eller fram
 
 ### Förbrukningsinventarier — halvt PBB
 
-Inventarier med anskaffningsvärde < halvt prisbasbelopp → direktavdrag. 2026: 29 600 kr (PBB 59 200 / 2). 2025: 28 950 kr (PBB 57 900 / 2). 2020: 23 650 kr.
+Inventarier med anskaffningsvärde < halvt prisbasbelopp → direktavdrag. **2026: 29 600 kr (PBB 59 200 / 2). 2025: 29 400 kr (PBB 58 800 / 2)**. 2020: 23 650 kr. *Obs:* PBB för 2025 är **58 800 kr**, inte 57 900 (det var 2024).
 
 För inventarier som **äga gemensamt** av flera näringsidkare (enkelt bolag): beloppsgränsen gäller för inventariet i sin helhet, **inte** delägarens andel.
 
@@ -170,15 +224,23 @@ Markanläggningar skrivs av med fast årlig procent (planenlig, inte restvärdes
 - **10%/år**: täckdiken och skogsvägar
 - **5%/år**: övriga markanläggningar (öppna diken, stängsel om de inte är markinventarier, bevattningsanläggningar i jorden, övriga, etc.)
 
-### Avskrivning av byggnader
+### Avskrivning av byggnader — skattemässiga satser
 
-| Byggnadstyp | %/år |
-|---|---|
-| Bostadshus (småhus och hyreshus) | 2 |
-| Växthus, silor och kylhus | 5 |
-| Övriga ekonomibyggnader | 4 |
+Skatteverkets vägledande procentsatser för värdeminskningsavdrag (SKV A 2005:5, ej tidsbegränsad) för byggnader på lantbruksenhet:
 
-(Skatteverkets allmänna råd för byggnader på lantbruksenhet — kan avvika från ÅRL/K3 som baseras på faktisk livslängd.)
+| Byggnadstyp | Skattemässig %/år | Implicit nyttjandeperiod |
+|---|---|---|
+| Bostadshus (småhus och hyreshus) | 2 | 50 år |
+| Växthus, silor och kylhus | 5 | 20 år |
+| Övriga ekonomibyggnader (stall, lador, maskinhallar) | 4 | 25 år |
+
+### Skillnad mot bokföringsmässig avskrivning per K-regelverk
+
+| Regelverk | Avskrivning i räkenskaperna | Avvikelse mot skattemässig |
+|---|---|---|
+| **K1** (förenklat årsbokslut för EF, BFNAR 2006:1) | Formellt samband: bokföringsmässig = skattemässig sats | **Ingen** — satserna ovan används direkt |
+| **K2** (mindre AB, BFNAR 2016:10) | Nyttjandeperiod, men förenkling tillåter SKV-satser | Vanligtvis **ingen** i praktiken |
+| **K3** (större AB, BFNAR 2012:1) | Faktisk nyttjandeperiod + obligatorisk komponentavskrivning | **Avviker nästan alltid** — ekonomibyggnad 40–60 års nyttjandeperiod (1,7–2,5 %/år) jämfört med skattemässig 4 %/år → kräver dubbla register och uppskjuten skatt |
 
 ## Skogsavdrag — skattemässig vs bokfört värde
 
@@ -186,11 +248,13 @@ Skogsavdrag **bokförs INTE i räkenskaperna**. Det är en ren skattemässig jus
 
 **Konsekvens**: Det bokförda värdet på skogsfastigheten (B7a i ruta-2196 räntefördelningsbilagan) blir större än det skattemässiga värdet (B7b). Skillnadsbeloppet (negativt) — sk **B7c** — påverkar kapitalunderlaget.
 
-**Worked example (Enar Gran)**:
-- Bokfört värde fastigheten 518 400 kr (B2/B3 på sid 1 NE → B7a på sid 2196)
-- Skattemässigt värde 473 400 kr (B7b)
-- Skillnad = −45 000 kr (förs in som minskning vid B-beräkningen)
-- Detta är **skogsavdraget som gjorts** men ej bokförts → skattemässigt har fastighetens omkostnadsbelopp minskat med 45 000 kr.
+**Räkneexempel (illustrativt)**:
+```
+bokfört_värde_fastighet = anskaffningsvärde − bokförda_avskrivningar    # → B7a på sid 2196
+skattemässigt_värde    = anskaffningsvärde − bokförda_avskrivningar − ack_skogsavdrag    # → B7b
+skillnad_B7c           = skattemässigt − bokfört = − ack_skogsavdrag    # negativ post i kapitalunderlaget
+```
+Exempel: bokfört 518 400 kr, ack_skogsavdrag 45 000 kr → skattemässigt 473 400 kr → B7c = −45 000 kr. Skogsavdraget bokförs aldrig, så B7c korrigerar för att fastighetens skattemässiga omkostnadsbelopp har minskat utan motsvarande bokföringspost.
 
 ## Ersättningsfond (IL 31 kap)
 
@@ -231,11 +295,15 @@ Dock: för ålderspensionärer är inkomstskatt + egenavgifter ofta lägre än 3
 | **Mark** | Anskaffning av mark som är kapitaltillgång |
 | **Djurlager** | Nedskrivning av djurlager. Fonden får tas i anspråk med högst ett belopp som motsvarar utgifterna under beskattningsåret för att anskaffa djur. Nedskrivningen får inte leda till att lagret tas upp till ett lägre värde i dess helhet vid beskattningsårets slut än som annars skulle ha godtagits. |
 
-### Återföring efter 3 år
+### Användningstid — förlängd 2026: 3 år → 10 år
 
-Ersättningsfonden måste användas inom **3 år** från avsättningen. I annat fall återförs den till beskattning i deklarationen som lämnas för det tredje beskattningsåret efter det att avdraget gjordes.
+**Skogsskattereformen 2026 (prop. 2025/26:69, ikraft 2026-04-01)** förlängde användningstiden för ersättningsfond:
+- **Före 2026-04-01**: avsättningen måste användas inom **3 år** från avsättningsåret. Dispens kunde medges i ytterligare högst 3 år.
+- **Fr.o.m. 2026-04-01**: avsättningen får användas inom **10 år**. Detta gäller också nya avsättningar gjorda från reformens ikraftträdande. (Övergångsregler för befintliga fonder — kontrollera mot SKV vid behov.)
 
-**Dispens**: Vid sjukdom, lågkonjunktur eller liknande kan Skatteverket medge dispens i ytterligare högst 3 år.
+I annat fall återförs den till beskattning i deklarationen som lämnas för det tionde (tidigare tredje) beskattningsåret efter det att avdraget gjordes.
+
+**Dispens**: Vid sjukdom, lågkonjunktur eller liknande kan Skatteverket medge dispens i ytterligare högst 3 år (oavsett om grundtiden är 3 eller 10 år).
 
 ### Tillägg vid återföring av annan orsak
 
@@ -260,10 +328,16 @@ Tillägget gäller **inte** vid expropriation och liknande.
 
 ### BAS-mapping för ersättningsfond
 
-Ersättningsfond är **inte** ett obeskattat reservkonto (skiljer sig från periodiseringsfond, expansionsfond, överavskrivningar). Det är en skattemässig konstruktion.
+Ersättningsfond skiljer sig från periodiseringsfond och expansionsfond: **den måste bokföras via resultaträkningen för att avdraget ska vara giltigt** (gäller även för EF under K1, undantag mark). Detta är **motsatsen** till P-fond/expansionsfond i EF som aldrig bokförs.
 
-- I förenklat årsbokslut redovisas avsättningen som obeskattad reserv i ruta U-fältet (för transparens).
-- I löpande bokföring: ingen specifik kontering — avdraget görs i deklarationen.
+```
+Debit  8xxx Avsättning till ersättningsfond  (resultatpåverkande)
+Credit 2060 Ersättningsfond                  (skuld-/eget kapitalsida)
+```
+
+- **I förenklat årsbokslut**: avsättningen bokförs i resultatet + upplysning i **ruta U3** (Ersättningsfond vid årets slut).
+- **Undantag: ersättningsfond för mark** behöver inte bokföras enligt BFNAR 2006:1 9.2 — endast U3-upplysning.
+- Detta ändrades **inte** av Skogsskattereformen 2026 — bokföringskravet kvarstår; däremot förlängdes användningstiden från 3 till 10 år (se skogsbeskattning.md).
 
 ## Räntefördelning — lantbruksspecifika regler
 
@@ -316,7 +390,7 @@ Den särskilda posten kan därmed aldrig leda till positiv räntefördelning uta
 
 ### Särskild post vid expansionsfond
 
-Övertar förvärvaren expansionsfond i samband med övertagandet, ska den särskilda posten ökas med **72% av den övertagna expansionsfonden** (= 100% − 27.7% expansionsfondsskatt). Den övertagna expansionsfonden räknas inte som vederlag för fastigheten.
+Övertar förvärvaren expansionsfond i samband med övertagandet, ska den särskilda posten ökas med **79,4 % av den övertagna expansionsfonden** (= 100 % − 20,6 % expansionsfondsskatt; bolagsskatten är 20,6 % sedan 2021). Den övertagna expansionsfonden räknas inte som vederlag för fastigheten. Äldre källor anger 72 % / 27,7 % baserat på den tidigare 21,4 %-bolagsskatten — kontrollera alltid mot aktuell sats.
 
 ## N8-blanketten — skogs- och substansminskningsavdrag
 
@@ -406,9 +480,10 @@ Uttaget är en intäkt i NV. Tas upp i ruta R27 på sid 2 NE.
 
 ### Periodiseringsfond, expansionsfond, ersättningsfond i EF
 
-Alla tre är **inte bokförda i räkenskaperna** för enskilda näringsidkare. De är skattemässiga konstruktioner i NE-bilagan. Däremot bör skogsägare som gör förenklat årsbokslut lämna upplysningar om dem i **ruta U1-U3** i bokslutet (för att visa banken och andra läsare hela bilden).
+- **Periodiseringsfond och expansionsfond**: **bokförs INTE** i räkenskaperna för enskilda näringsidkare. De är skattemässiga konstruktioner i NE-bilagan. Upplysning lämnas i ruta U1 (P-fond) respektive U2 (expansionsfond) i förenklat årsbokslut.
+- **Ersättningsfond**: **ska bokföras via resultaträkningen** för avdragsrätt (debit 8xxx / credit 2060). Detta är motsatsen till P-fond/expansionsfond. Upplysning i ruta U3. Undantag: ersättningsfond för mark behöver inte bokföras (BFNAR 2006:1 9.2).
 
-I ruta U4 lämnas upplysning om bokförda intäkter som helt eller till viss del är obeskattade — det gäller skogskonto, insatsemission och betalningsplan på skog.
+I ruta U4 lämnas upplysning om bokförda tillgångar/intäkter som helt eller till viss del är obeskattade — det gäller skogskonto, insatsemission och betalningsplan på skog. Själva saldot på skogskonto bokförs alltid i B9 (Kassa och bank); U4 markerar bara att framtida uttag blir skattepliktig NV-intäkt.
 
 ## Cross-references
 

--- a/.claude/skills/swedish-jordbruk-skogsbruk/references/lantbruks-moms.md
+++ b/.claude/skills/swedish-jordbruk-skogsbruk/references/lantbruks-moms.md
@@ -1,0 +1,205 @@
+# Lantbruksspecifik moms
+
+General moms compliance covered by `swedish-vat`. This file covers only **lantbruksspecifika undantag och specialfall** — particularly hög/låg moms-gränsdragningar, solcellsmoms (HFD 2019), hästverksamhet, avverkningsuppdrag med kontantmetod, förskott, samt momslyft i uppbyggnadsskedet.
+
+## Yrkesmässighet — momsregistrering
+
+Den som har en näringsfastighet (lantbruksenhet) anses **yrkesmässig**, men det räcker INTE enligt Skatteverket. Enbart innehav av en näringsfastighet, utan avsikt att bedriva en verksamhet som medför momspliktig omsättning, är inte tillräckligt för att registrera ägaren till mervärdesskatt och för att medge momslyft.
+
+Skatteverkets ställningstagande **2007-06-29, Dnr 131 604139-06/111** — Yrkesmässighet vid innehav av näringsfastighet mm.
+
+För att vara säker på att få bli momsregistrerad bör du alltså kunna bevisa att du kommer att ha (eller redan har haft) momspliktig försäljning i verksamheten.
+
+## Hög eller låg moms?
+
+Tre momsnivåer i Sverige: **25%, 12%, 6%**.
+
+### Skogsprodukter
+
+Skogen ger **råvaror** som inte är livsmedel → **25% moms** på alla skogsprodukter:
+- Virke
+- Massaved
+- Skogsbränsle (flis)
+- Energiskog från skogsbruk
+- Julgranar och dekorationsgrönt
+- Vid, om från skogsbruk
+
+### Jordbruksprodukter
+
+Jordbruksprodukter avsedda att förtäras av människor → **12% livsmedelmoms**.
+
+| Produkt | Moms när |
+|---|---|
+| Levande djur (slakt- och livdjur), när säljs till slakteriet | **25%** (djuren är ännu inte livsmedel) |
+| Kött (när köttet säljs på gården eller direkt till konsument) | **12%** |
+| Mjölk (oavsett om till mejeriet eller direkt till konsument) | **12%** |
+| Spannmål, frukt, rotfrukter, grönsaker — avsedda att förtäras av människor | **12%** |
+| Spannmål, frukt etc. avsedd för djurfoder | **25%** |
+| Energigrödor som ska användas för energiproduktion (men inte föda) | **25%** |
+| Fisk och skaldjur | **12%** (alltid livsmedel) |
+| Bär, frukter och grönsaker — själv-plock | **12%** (livsmedel) |
+| Sädeskärvar för utfodring av fåglar | **25%** (inte livsmedel för människor) |
+
+### Direktförsäljning till konsumenter
+
+All försäljning av livsmedel direkt till konsumenter (gårdsbutik, granne eller andra) → **12%**, oavsett om man säljer en gris/halv ko/kvarn.
+
+Det du säljer betraktas då alltid som livsmedel och inte som råvaror oavsett om det är spannmål, mjöl, kött eller livande mjölk.
+
+### Servering / catering
+
+12% moms på serveringstjänster (utom på vin, sprit och starköl, som är 25%).
+
+### Egna uttag (uttagsmoms)
+
+Om du tar ut tjänster eller varor för egen del ur lantbruket:
+- Uttag av **varor** → momsen beräknas på **inköpspriset** (eller självkostnadspriset om inget inköpspris finns).
+- Uttag av **tjänster** → momsen beräknas på kostnaden för att tillhandahålla tjänsten. Om en varas marknadsvärde är lägre än inköpspriset används marknadsvärdet vid uttagsmomsberäkningen.
+- I inkomstdeklarationen värderas uttagen till **marknadspris**.
+- Uttag av livsmedel från lantbruket till dig själv, din familj och närstående → **12% moms** (låg moms).
+
+**Worked example (uttag kött)**:
+- Lisbeth slaktar en 30 månader gammal Belted Galloway-stut, slaktvikt 300 kg, för eget bruk.
+- Hon tar upp uttaget i inkomstdeklarationen till marknadsvärde 30 kr/kg inkl moms.
+- Moms 12% (baklänges 10.71%) → 30 × 10.71% = **3.21 kr** moms per kg.
+- Förmånsvärde exkl moms = 26.79 kr/kg → 300 × 26.79 = **8 037 kr** förmånsvärde.
+
+För moms (utgående):
+- Marknadsvärdet räknas inte (utan inköpsvärdet eller annan jämförelse). Stuten var född på gården → inget inköpspris.
+- Skatteverkets djurvärden: produktionskostnad gödnöt 10 kr/kg levande vikt. Levande vikt = 2 × slaktvikt = 600 kg. Värde 600 × 10 = 6 000 kr.
+- Utgående moms 12% × 6 000 = **720 kr**.
+
+## Att lyfta moms — undantag
+
+Den moms du som momsredovisande jord- och skogsbrukare betalar får du (med vissa undantag) tillbaka från Skatteverket. På vissa utgifter får du INTE lyfta momsen, trots att utgiften hör till skogs- eller jordbruksdriften.
+
+### Undantag
+
+1. **Mangårdsbyggnaden och andra byggnader som är stadigvarande bostäder** även om de är näringsfastigheter (förbudet mot momslyft på stadigvarande bostad).
+2. **Personbilsmoms i lantbruket (förmånsbil)** vid inköp: ingen lyft. Bara på löpande utgifter för personbilen (drivmedel, reparationer) får du lyfta momsen. Du ska inte heller redovisa moms när du säljer personbilen. På leasingutgifter för personbil får du lyfta **halva** momsen (om bilen används minst 100 mil/år i företaget).
+3. **Köp från privatperson, ideell förening eller någon annan som inte redovisar moms** — ingen ingående moms att lyfta. Men du ska redovisa utgående moms om du senare säljer tillgången.
+4. **Ingångsinventarier och ingångslager** — sådant som du först haft i den enskilda firman vid starten och som du tidigare haft privat: ingen ingående moms att lyfta. Men du ska redovisa utgående moms om du senare säljer tillgången.
+5. **Hö till privata ridhästar**: om du köper hö till din privata ridhäst får du varken dra av utgiften för höet eller lyfta momsen.
+
+### Säljarens momsregistreringsnummer
+
+För att du ska få lyfta momsen på en utgift måste momsen finnas angiven i kronor på kvittot eller på fakturan. Säljarens momsregistreringsnummer ska finnas med på kvittot eller fakturan.
+
+## Hästverksamhet på lantbruksfastighet — yrkesmässighet
+
+Hästhållning ingår **inte** automatiskt i näringsverksamheten, även om hästen eller hästarna finns på lantbruksfastigheten. Skatteverket bedömer **vinstsyfte** för hästverksamheten separat.
+
+Räcker det inte (verksamheten räknas som **privat**), kan företaget inte få lyfta moms på den del av verksamheten som hör till privathästeriet, varken på anskaffningar eller löpande utgifter. Inte heller på inredning och reparationer i lantbrukets ekonomibyggnader som används för den privata hästhållningen.
+
+**Skatteverkets ställningstaganden**:
+- **Avdrag för hästhållning vid innehav av jordbruksfastighet**, 2007-02-12, Dnr 131 104860-07/111
+- **Yrkesmässighet vid innehav av näringsfastighet mm samt fråga om sponsorbidrag**, 2007-06-29, Dnr 131 604139-06/111
+
+### Hästar som utnyttjas både i NV och privat
+
+Två metoder som ger samma slutresultat:
+1. **Du lyfter momsen på allt**. Sedan återför du den privata delen av momsen som ett **eget uttag** (uttagsmoms).
+2. **Du lyfter bara den del av momsen som hör till NV**. Resten ingår i den privata utgiften. Ingen uttagsbeskattning.
+
+### Hobbyhästar momslyft trots hobbyverksamhet
+
+KR i Jönköping mål 2575-2578-08 — en man som sysslade med grävning som extraarbete, utan vinstsyfte, köpte i en ny traktor. Kammarrätten gjorde bedömningen att det handlade om ekonomisk verksamhet eftersom mannen hade (begränsade) intäkter. Han fick därmed lyfta den ingående momsen på traktorn.
+
+## Solceller på lantbruk — moms
+
+Beskattningen styrs av **vad anläggningen ska leverera el till**.
+
+Skatteverkets ställningstagande **131 44577-17/111**:
+
+| Scenario | Beskrivning | Momslyft |
+|---|---|---|
+| **All el levereras in på elnätet mot ersättning** | Anläggningen i sin helhet kommer användas i momspliktig verksamhet | **100%** |
+| **Leverans av el till både mangårdsbyggnad och ekonomibyggnad** där momspliktig verksamhet bedrivs. Solcellerna är installerade på en ekonomibyggnad. Endast överskottet säljs till ett elhandelsföretag. | Eftersom el inte bara levereras till en byggnad som omfattas av förbudet mot momslyft på stadigvarande bostad, har man rätt att lyfta en del av momsen. Samma bedömning görs om solcellerna installeras på mangårdsbyggnaden för att leverera el till båda byggnaderna. | **DELVIS** — den del som hör till ekonomibyggnaden |
+| **Installerad på mangårdsbyggnad** — el levereras enbart till den byggnaden, som är stadigvarande bostad. Endast överskottet ska säljas till ett elhandelsföretag. | Syftet med installationen får anses vara att anläggningen ska leverera el till byggnaden. Eftersom anläggningen kommer att leverera el till en byggnad som avser stadigvarande bostad gäller förbudet för momslyft på stadigvarande bostad. | **INGEN** |
+
+Bedömningen blir densamma om installationen görs på ekonomibyggnaden eller på annan plats på jordbruksfastigheten för att enbart leverera el till mangårdsbyggnaden.
+
+### HFD-domen 2019
+
+**Högsta förvaltningsdomstolens dom 2019-10-25, mål nr 6174-18, 6175-18 och 6177-18** rörde ingående moms på solcellsanläggningar.
+
+Domen klargjorde att även en mycket liten momspliktig användning (försäljning av överskottsel) kan ge rätt till momslyft på en del av installationen.
+
+Med anledning av domen kommer Skatteverket att se över följande ställningstaganden:
+- **2018-03-01, dnr 202 90662-18/111**, Avdragsrätt för mervärdesskatt vid inköp och installation av en solcellsanläggning för mikroproduktion av el
+- **2017-12-20, dnr 202 492055-17/111**, Beskattningskonsekvenser för den som har en solcellsanläggning på sin jordbruksfastighet
+- **2017-12-20, dnr 202 492052-17/111**, Beskattningskonsekvenser för den som har en solcellsanläggning på sin villa eller fritidshus som är privatbostad
+
+### Energiskatt
+
+- Toppeffekt < **255 kW** (motsvarar ungefär 30 normala villor) och ingen el överförs till elnätet → ingen energiskatt.
+- All el som överförs till koncessionspliktiga elnätet → energiskatt ska betalas. Det är dock i regel köparen av den el som överförs till det koncessionspliktiga elnätet som ska redovisa energiskatten på denna del.
+
+## Förskott på leveransvirke — moms vs inkomstskatt-asymmetri
+
+När du får förskott för virke som du varken levererat eller fått inmätt:
+- **Inkomstskatt**: Du tar upp förskottet som en **skuld**, ej intäkt. Du behöver alltså inte skatta för beloppet förrän du levererar virket eller får det inmätt.
+- **Moms**: Du ska däremot redovisa **moms på det**, om den som har betalat ut förskottet har specificerat moms på det kvitto eller den faktura. Det räknas nämligen som förskott på en **beställd vara**, trots att det egentligen inte är en bestämd vara.
+- **Skogsavdrag/skogskonto**: Förskottet är **inte underlag** för skogsavdrag och inte heller underlag för insättning på skogskonto.
+
+Denna asymmetri mellan moms (omedelbar) och inkomstskatt (väntar tills inmätning) är en specialfall som måste hanteras manuellt i bokföringsprogram.
+
+## Avverkningsuppdrag och kontantmetoden
+
+Om du kommer överens med köparen om att likviden för en avverkningsrätt ska fördelas på flera år (**betalningsplan**), får du redovisa inkomsterna **kontantmässigt** för inkomstskatt — du skattar bara för de pengar du fått in under året.
+
+Det är likadant med momsen — **du ska bara redovisa momsen på den likvid du fått under året**. Detta är ett undantag från huvudregeln att moms ska redovisas vid leverans/inmätning.
+
+Detta är en av få fall där moms och inkomstskatt följer varandra (kontantprincipen i båda).
+
+## Arrende och moms
+
+- **Jordbruksarrende**: 25% moms.
+- **Jakt- och fiskearrende**: 25% moms.
+- **Tomtarrende** (bostadsarrende eller lägenhetsarrende): **MOMSFRITT**.
+
+Arrendatorn (vid jordbruksarrende) får lyfta hela momsen på arrendet, även om värdet av bostad ingår i arrendet. Däremot får arrendatorn inte i inkomstdeklarationen dra av en kostnad för den del av arrende-avgiften som hör till bostaden.
+
+## Momsen i uppbyggnadsskede
+
+Normalt har ett företag rätt att lyfta moms på sina utgifter först från och med att företaget har sin första momspliktiga omsättning, dvs sin första försäljning, och är momsregistrerat.
+
+Du kan dock ansöka om att få återbetalning av moms **innan verksamheten gett några intäkter**. Det måste vara fråga om **nödvändiga utgifter** för att dra igång verksamheten, exempelvis köp av en maskin.
+
+Företaget kan också lyfta momsen på utgifterna när företaget är i uppbyggnadsskedet om företaget är momsregistrerat. Missa därför inte att så snabbt som möjligt lämna in Företagsregistrering till Skatteverket för att få företaget momsregistrerat. Att företaget är i ett uppbyggnadsskede är ett **särskilt skäl** för att en momsregistrering ska beviljas, även om företaget inte har haft eller kommer att ha någon omsättning inom den närmaste tiden.
+
+KR i Jönköping (1115-08, 1170-08): Verksamhet under uppbyggnad kan generera momslyft även när det dröjer flera år innan momspliktiga intäkter uppkommer.
+
+## Momsredovisning för lantbruk
+
+Beskattningsunderlag (totala momsbelagda inkomsterna exklusive moms):
+- **≤ 1 MSEK**: helår, momsdeklaration **senast 12 maj** året efter beskattningsåret (eller 26 februari året efter om EU-handel skett).
+- **1-40 MSEK**: kvartal eller månad (lantbrukare väljer ofta månad om man har stora investeringar och vill få tillbaka moms snabbare).
+- **> 40 MSEK**: månad.
+
+### Faktureringsmetoden vs bokslutsmetoden
+
+För lantbrukare:
+- **Faktureringsmetoden**: bokföra fakturorna när de skickas / mottas. Moms redovisas direkt.
+- **Bokslutsmetoden** (kontantmetoden): bokföra fakturorna när de **betalas**. Räcker för nettoomsättning ≤ 3 MSEK. Vid räkenskapsårets slut tas obetalda fakturor med (matchning).
+
+De flesta små lantbruk använder bokslutsmetoden + förenklat årsbokslut.
+
+## Privata hästar — momslyft
+
+Privata ridhästar/sporthästar på lantbruksfastigheten räknas som **privat** användning. Konsekvens:
+
+- Ingen momslyft på utgifter som rör hästhållningen (foder, veterinär, etc.).
+- Ingen momslyft på inredning och reparationer i lantbrukets ekonomibyggnader som används för privata hästhållningen.
+- Om en byggnad används både för momspliktig verksamhet och privat hästhållning: proportionering av momslyften.
+
+Skatteverkets ställningstaganden:
+- Dnr 131 104860-07/111
+- Dnr 131 604139-06/111
+
+## Cross-references
+
+- General momsregler, rutor 05-62, omvänd skattskyldighet → `swedish-vat`
+- Tomtarrende, lägenhetsarrende, fastighetsmoms allmänt → `swedish-vat`
+- Solceller på privatbostad (kapital) — inte i denna skill, se kapital-skattning
+- Momsfri försäljning vid uttag till anställd kost → `swedish-payroll`

--- a/.claude/skills/swedish-jordbruk-skogsbruk/references/lantbruks-moms.md
+++ b/.claude/skills/swedish-jordbruk-skogsbruk/references/lantbruks-moms.md
@@ -26,29 +26,31 @@ Skogen ger **råvaror** som inte är livsmedel → **25% moms** på alla skogspr
 
 ### Jordbruksprodukter
 
-Jordbruksprodukter avsedda att förtäras av människor → **12% livsmedelmoms**.
+Jordbruksprodukter avsedda att förtäras av människor → **6 % livsmedelmoms** (tillfälligt sänkt från 12 % under perioden **1 april 2026 – 31 december 2027** enligt prop. 2025/26:55). Övergångsregel: leveransdatum styr satsen, inte fakturadatum.
 
-| Produkt | Moms när |
-|---|---|
-| Levande djur (slakt- och livdjur), när säljs till slakteriet | **25%** (djuren är ännu inte livsmedel) |
-| Kött (när köttet säljs på gården eller direkt till konsument) | **12%** |
-| Mjölk (oavsett om till mejeriet eller direkt till konsument) | **12%** |
-| Spannmål, frukt, rotfrukter, grönsaker — avsedda att förtäras av människor | **12%** |
-| Spannmål, frukt etc. avsedd för djurfoder | **25%** |
-| Energigrödor som ska användas för energiproduktion (men inte föda) | **25%** |
-| Fisk och skaldjur | **12%** (alltid livsmedel) |
-| Bär, frukter och grönsaker — själv-plock | **12%** (livsmedel) |
-| Sädeskärvar för utfodring av fåglar | **25%** (inte livsmedel för människor) |
+| Produkt | Moms 2026-04-01 → 2027-12-31 | Moms före 2026-04-01 och fr.o.m. 2028-01-01 |
+|---|---|---|
+| Levande djur (slakt- och livdjur), när säljs till slakteriet | **25 %** (djuren är ännu inte livsmedel) | 25 % |
+| Kött (på gården eller direkt till konsument) | **6 %** | 12 % |
+| Mjölk (oavsett mottagare) | **6 %** | 12 % |
+| Spannmål, frukt, rotfrukter, grönsaker — avsedda att förtäras av människor | **6 %** | 12 % |
+| Spannmål, frukt etc. avsedd för djurfoder | **25 %** | 25 % |
+| Energigrödor för energiproduktion | **25 %** | 25 % |
+| Fisk och skaldjur (alltid livsmedel) | **6 %** | 12 % |
+| Bär, frukter, grönsaker — själv-plock (livsmedel) | **6 %** | 12 % |
+| Sädeskärvar för utfodring av fåglar (inte människoföda) | **25 %** | 25 % |
 
 ### Direktförsäljning till konsumenter
 
-All försäljning av livsmedel direkt till konsumenter (gårdsbutik, granne eller andra) → **12%**, oavsett om man säljer en gris/halv ko/kvarn.
+All försäljning av livsmedel direkt till konsumenter (gårdsbutik, granne, marknad, REKO-ring etc.) → **6 % under perioden 2026-04-01 till 2027-12-31** (annars 12 %), oavsett om man säljer en gris, halv ko eller kvarn.
 
-Det du säljer betraktas då alltid som livsmedel och inte som råvaror oavsett om det är spannmål, mjöl, kött eller livande mjölk.
+Det du säljer betraktas då som livsmedel, inte råvara — oavsett om det är spannmål, mjöl, kött eller mjölk.
 
 ### Servering / catering
 
-12% moms på serveringstjänster (utom på vin, sprit och starköl, som är 25%).
+Servering på plats (restaurang/servering, oavsett tillagat eller utlevererat) behåller **12 %** även under sänkningsperioden — den tillfälliga 6 %-sänkningen gäller **inte servering**. Vin, sprit och starköl: 25 % som vanligt.
+
+**Avhämtning / take-away** behandlas som livsmedelsförsäljning → **6 %** under sänkningsperioden (annars 12 %). Gränsdragningen mellan servering och avhämtning blir därför viktig att kunna styrka.
 
 ### Egna uttag (uttagsmoms)
 
@@ -56,18 +58,29 @@ Om du tar ut tjänster eller varor för egen del ur lantbruket:
 - Uttag av **varor** → momsen beräknas på **inköpspriset** (eller självkostnadspriset om inget inköpspris finns).
 - Uttag av **tjänster** → momsen beräknas på kostnaden för att tillhandahålla tjänsten. Om en varas marknadsvärde är lägre än inköpspriset används marknadsvärdet vid uttagsmomsberäkningen.
 - I inkomstdeklarationen värderas uttagen till **marknadspris**.
-- Uttag av livsmedel från lantbruket till dig själv, din familj och närstående → **12% moms** (låg moms).
+- Uttag av livsmedel från lantbruket till dig själv, din familj och närstående → **6 % moms under 2026-04-01 till 2027-12-31** (annars 12 %).
 
-**Worked example (uttag kött)**:
-- Lisbeth slaktar en 30 månader gammal Belted Galloway-stut, slaktvikt 300 kg, för eget bruk.
-- Hon tar upp uttaget i inkomstdeklarationen till marknadsvärde 30 kr/kg inkl moms.
-- Moms 12% (baklänges 10.71%) → 30 × 10.71% = **3.21 kr** moms per kg.
-- Förmånsvärde exkl moms = 26.79 kr/kg → 300 × 26.79 = **8 037 kr** förmånsvärde.
+**Räkneexempel (uttag kött, slaktnöt självrekryterande)**:
 
-För moms (utgående):
-- Marknadsvärdet räknas inte (utan inköpsvärdet eller annan jämförelse). Stuten var född på gården → inget inköpspris.
-- Skatteverkets djurvärden: produktionskostnad gödnöt 10 kr/kg levande vikt. Levande vikt = 2 × slaktvikt = 600 kg. Värde 600 × 10 = 6 000 kr.
-- Utgående moms 12% × 6 000 = **720 kr**.
+Uttag av eget slaktat nötkött, slaktvikt 300 kg, för privat konsumtion.
+
+```
+inkomstdeklaration (förmånsvärde):
+  marknadsvärde_inkl_moms = 30 kr/kg     # exempelpris
+  moms_andel (6 % baklänges) = 6 / 106 = 5,66 %
+  förmånsvärde_exkl_moms = 30 × (1 - 0,0566) ≈ 28,30 kr/kg
+  totalt_förmånsvärde = 300 × 28,30 = 8 490 kr
+
+uttagsmoms (utgående moms):
+  # marknadsvärde används INTE — använd produktionskostnad enligt SKVFS
+  # Slaktnöt självrekryterande SKVFS 2025:27: 21,80 kr/kg levande vikt
+  levande_vikt = 2 × slaktvikt = 600 kg
+  uttagsvärde = 600 × 21,80 = 13 080 kr
+  utgående_moms = 13 080 × 0,06 = 785 kr        # 6 % under 2026-04-01 → 2027-12-31
+  # (12 % före 2026-04-01 och fr.o.m. 2028-01-01: 13 080 × 0,12 = 1 570 kr)
+```
+
+Notera asymmetrin: marknadspris styr **inkomstdeklarationen** (förmånsvärde), medan produktionsutgift från SKVFS styr **uttagsmomsen**. Det är vanligen mer förmånligt för näringsidkaren än ett enhetligt marknadsvärde.
 
 ## Att lyfta moms — undantag
 
@@ -119,27 +132,68 @@ Skatteverkets ställningstagande **131 44577-17/111**:
 
 Bedömningen blir densamma om installationen görs på ekonomibyggnaden eller på annan plats på jordbruksfastigheten för att enbart leverera el till mangårdsbyggnaden.
 
-### HFD-domen 2019
+### HFD-domen 2019 — rättsläge för momslyft
 
-**Högsta förvaltningsdomstolens dom 2019-10-25, mål nr 6174-18, 6175-18 och 6177-18** rörde ingående moms på solcellsanläggningar.
+**HFD 2019-10-25, mål nr 6174-18, 6175-18 och 6177-18** klargjorde att även en mycket liten momspliktig användning (försäljning av överskottsel) kan ge rätt till momslyft på en proportionerlig del av installationen.
 
-Domen klargjorde att även en mycket liten momspliktig användning (försäljning av överskottsel) kan ge rätt till momslyft på en del av installationen.
+Bedömningen kvarstår oförändrad enligt Skatteverkets nuvarande vägledning (Rättslig vägledning utg. 2024.5, dok 394014 — *Beskattningskonsekvenser för den som har en solcellsanläggning på sin jordbruksfastighet*), som **ersätter** tidigare ställningstaganden:
+- 2018-03-01, dnr 202 90662-18/111 (avdragsrätt vid inköp och installation)
+- 2017-12-20, dnr 202 492055-17/111 (jordbruksfastighet)
+- 2017-12-20, dnr 202 492052-17/111 (villa/fritidshus som privatbostad)
+- 2020-11-10, dnr 8-112186 (samma rubrik, äldre version)
 
-Med anledning av domen kommer Skatteverket att se över följande ställningstaganden:
-- **2018-03-01, dnr 202 90662-18/111**, Avdragsrätt för mervärdesskatt vid inköp och installation av en solcellsanläggning för mikroproduktion av el
-- **2017-12-20, dnr 202 492055-17/111**, Beskattningskonsekvenser för den som har en solcellsanläggning på sin jordbruksfastighet
-- **2017-12-20, dnr 202 492052-17/111**, Beskattningskonsekvenser för den som har en solcellsanläggning på sin villa eller fritidshus som är privatbostad
+**ML 1994:200 → ML 2023:200** trädde ikraft 1 juli 2023. Gamla paragrafhänvisningar i ovan ställningstaganden är inaktuella men den rättsliga bedömningen är oförändrad.
+
+### Grönt avdrag på lantbruksfastighet — två elabonnemang krävs
+
+För att privatbostadsdelen ska få **skattereduktion för grön teknik** (grönt avdrag) på en solcellsinstallation måste Skatteverket kunna säkerställa att den egenproducerade elen **i princip endast** kommer småhuset (mangårdsbyggnaden) tillgodo.
+
+**Praktiska kravet (Skatteverket fr.o.m. 2024-03-22)**: **två separata elabonnemang/elmätare** krävs på fastigheten — ett för småhuset, ett för ekonomibyggnad/näringsdelen. Solcellsanläggningen ska vara ansluten till småhusets abonnemang.
+
+Bakgrund: tidigare tillämpade Skatteverket en **schablon på 5 %** — om högst 5 % av producerad el bedömdes "spilla över" till annan byggnad kunde grönt avdrag ändå medges. Denna schablon **upphörde 2024-03-22**. Nuvarande krav är fysisk separation av elnäten.
+
+Konsekvens för typsituationer:
+
+| Scenario | Grönt avdrag möjligt? |
+|---|---|
+| Solceller på småhus + småhus har eget elabonnemang separat från ekonomibyggnad/stall | **JA** |
+| Solceller på småhus, gemensamt elabonnemang för småhus + hönsstall (elvärme i stallet) | **NEJ** — utan separat mätning antas el "spilla över" till näringsdelen |
+| Solceller på ekonomibyggnad, levererar bara till näringsverksamhet | Ingen grönt avdrag (näringsfastighet), men momslyft enligt HFD 2019 |
+| Solceller med viss leverans till båda byggnader | Proportionerligt momslyft för näringsdelen; **inget grönt avdrag för småhusdelen** utan separat mätning |
 
 ### Energiskatt
 
 - Toppeffekt < **255 kW** (motsvarar ungefär 30 normala villor) och ingen el överförs till elnätet → ingen energiskatt.
 - All el som överförs till koncessionspliktiga elnätet → energiskatt ska betalas. Det är dock i regel köparen av den el som överförs till det koncessionspliktiga elnätet som ska redovisa energiskatten på denna del.
 
+### Skattereduktion för såld förnybar el — SLOPAS 2026-01-01
+
+Den s.k. **60-öres-regeln** (skattereduktion för mikroproduktion av förnybar el, max 18 000 kr/år vid utbetalning för upp till 30 000 kWh) **avskaffas 1 januari 2026** (riksdagsbeslut SkU17 2024/25, prop. 2024/25:109).
+
+Praktisk effekt för lantbruk med solcellsanläggning som säljer överskott:
+- Tidigare: 60 öre/kWh skattereduktion på upp till 30 000 kWh sålda → max 18 000 kr/år
+- 2026 och framåt: 0 kr — endast spotpris från elhandelsföretaget + eventuell elcertifikat-/ursprungsgaranti-ersättning
+- Övriga skatteregler (moms enligt tabellerna ovan, inkomstbeskattning som NV om monterat på näringsbyggnad) gäller fortsatt
+
+### Grönt avdrag — sats och tak
+
+Subventionsgrad (lagstadgad):
+- Före 2025-07-01: **20 %** av arbets-/materialkostnad
+- Fr.o.m. 2025-07-01: **15 %** av arbets-/materialkostnad
+
+Tak: max **50 000 kr/år** per person i grönt avdrag (kombinerat för alla grön-teknik-installationer).
+
+De effektiva procentsatser som ofta citeras (**19,4 % före / 14,55 % efter**) uppstår när bara 97 % av en typisk faktura räknas som kvalificerad — 20 % × 97 % = 19,4 % och 15 % × 97 % = 14,55 %. Detta är effektiva fakturareduktioner, inte lagstadgad sats. Skatteverket har också (2024-08) klargjort att **växelriktare** räknas till de 15 %-kvalificerade kostnaderna, inte separat högre sats som vissa leverantörer marknadsförde.
+
+Avdraget gäller **bara privatpersoner**, inte näringsverksamhet. För **näringsfastighet** finns inget grönt avdrag — istället sker momslyft (per HFD 2019 och dnr 131 44577-17/111) och NV-avdrag för anskaffningen som inventarium eller byggnadsinventarium.
+
+Lantbrukare med privatbostadsdel av lantbruksfastighet kan utnyttja grönt avdrag *för den privata delen* — men endast om kravet på två elabonnemang ovan är uppfyllt.
+
 ## Förskott på leveransvirke — moms vs inkomstskatt-asymmetri
 
 När du får förskott för virke som du varken levererat eller fått inmätt:
 - **Inkomstskatt**: Du tar upp förskottet som en **skuld**, ej intäkt. Du behöver alltså inte skatta för beloppet förrän du levererar virket eller får det inmätt.
-- **Moms**: Du ska däremot redovisa **moms på det**, om den som har betalat ut förskottet har specificerat moms på det kvitto eller den faktura. Det räknas nämligen som förskott på en **beställd vara**, trots att det egentligen inte är en bestämd vara.
+- **Moms**: Du ska däremot redovisa **moms på det** om den som har betalat ut förskottet har specificerat moms på kvittot eller fakturan. Skattskyldighet vid förskott uppkommer enligt momslagen (ML 2023:200, 7 kap.) vid leverans av "**bestämd och beställd vara**" — i skogskontexten är varan *beställd* (avtal med virkesköparen finns) även om volymen/kvaliteten inte är *bestämd* förrän vid avverkning/inmätning. När säljaren har angett moms på fakturan har Skatteverkets praxis varit att betrakta omständigheterna som tillräckligt identifierade för att momsen ska redovisas direkt vid förskottet.
 - **Skogsavdrag/skogskonto**: Förskottet är **inte underlag** för skogsavdrag och inte heller underlag för insättning på skogskonto.
 
 Denna asymmetri mellan moms (omedelbar) och inkomstskatt (väntar tills inmätning) är en specialfall som måste hanteras manuellt i bokföringsprogram.

--- a/.claude/skills/swedish-jordbruk-skogsbruk/references/lantbruks-moms.md
+++ b/.claude/skills/swedish-jordbruk-skogsbruk/references/lantbruks-moms.md
@@ -102,6 +102,8 @@ För att du ska få lyfta momsen på en utgift måste momsen finnas angiven i kr
 
 Hästhållning ingår **inte** automatiskt i näringsverksamheten, även om hästen eller hästarna finns på lantbruksfastigheten. Skatteverket bedömer **vinstsyfte** för hästverksamheten separat.
 
+**Utveckling 2024**: HFD slog 2024 fast att tävling med trav-/galopphäst mot **garanterad startpeng** utgör ekonomisk verksamhet, och Skatteverket har sett över sitt ställningstagande. En trav-/galoppverksamhet med betydande garanterade startpengar kan därmed numera vara momspliktig även om den tidigare hade bedömts som hobby. Läs de äldre ställningstagandena nedan mot den bakgrunden.
+
 Räcker det inte (verksamheten räknas som **privat**), kan företaget inte få lyfta moms på den del av verksamheten som hör till privathästeriet, varken på anskaffningar eller löpande utgifter. Inte heller på inredning och reparationer i lantbrukets ekonomibyggnader som används för den privata hästhållningen.
 
 **Skatteverkets ställningstaganden**:
@@ -134,7 +136,7 @@ Bedömningen blir densamma om installationen görs på ekonomibyggnaden eller p�
 
 ### HFD-domen 2019 — rättsläge för momslyft
 
-**HFD 2019-10-25, mål nr 6174-18, 6175-18 och 6177-18** klargjorde att även en mycket liten momspliktig användning (försäljning av överskottsel) kan ge rätt till momslyft på en proportionerlig del av installationen.
+**HFD 2019 ref. 50** (HFD 2019-10-25, mål nr 6174-18, 6175-18 och 6177-18) klargjorde att även en mycket liten momspliktig användning (försäljning av överskottsel) kan ge rätt till momslyft på en proportionerlig del av installationen. Målet gällde en bostadsrättsförening; principen tillämpas analogt på solcellsanläggningar på lantbruksfastighet.
 
 Bedömningen kvarstår oförändrad enligt Skatteverkets nuvarande vägledning (Rättslig vägledning utg. 2024.5, dok 394014 — *Beskattningskonsekvenser för den som har en solcellsanläggning på sin jordbruksfastighet*), som **ersätter** tidigare ställningstaganden:
 - 2018-03-01, dnr 202 90662-18/111 (avdragsrätt vid inköp och installation)
@@ -163,7 +165,7 @@ Konsekvens för typsituationer:
 
 ### Energiskatt
 
-- Toppeffekt < **255 kW** (motsvarar ungefär 30 normala villor) och ingen el överförs till elnätet → ingen energiskatt.
+- Installerad toppeffekt < **500 kW** (gränsen höjdes från 255 kW 2021) → undantag från energiskatt på egenförbrukad el.
 - All el som överförs till koncessionspliktiga elnätet → energiskatt ska betalas. Det är dock i regel köparen av den el som överförs till det koncessionspliktiga elnätet som ska redovisa energiskatten på denna del.
 
 ### Skattereduktion för såld förnybar el — SLOPAS 2026-01-01

--- a/.claude/skills/swedish-jordbruk-skogsbruk/references/lantbruksfastighet.md
+++ b/.claude/skills/swedish-jordbruk-skogsbruk/references/lantbruksfastighet.md
@@ -17,7 +17,7 @@ A lantbruksenhet is normally a **mixed** fastighet from a skattesynpunkt: some p
 - Åkermark, betesmark
 - Ekonomibyggnader (lagårdar, stallbyggnader, logar, lador, silor, maskinhallar, verkstadsbyggnader)
 - Bostadshus där varken ägaren eller någon närstående bor på mer än 50% av bostadsytan
-- Mangårdsbyggnader med tre eller fler lägenheter (alltid näringsfastighet)
+- Mangårdsbyggnad inrättad som bostad åt **fler än två familjer** (alltid näringsfastighet, IL 2 kap 9§)
 
 ### Avsikt att bo
 
@@ -161,7 +161,7 @@ Sådana villkor får man **endast** i gåvo- eller testamentsavtal — inte i k�
 
 - Skogskonto-medel **kan stå kvar** även om fastigheten är såld eller bortskänkt.
 - Pengarna beskattas som inkomst av (oftast passiv) NV i den takt de tas ut, av den ursprunglige innehavaren.
-- För en pensionär är detta ofta **oförmånligt** (24,26 % särskild löneskatt enligt SLF, lag 1990:659, i stället för 10,21 % egenavgifter).
+- För en pensionär är detta ofta **oförmånligt** (24,26 % särskild löneskatt enligt SLF, lag 1990:659, i stället för 10,21 % ålderspensionsavgift som en pensionär annars betalar på aktiv NV; full aktiv egenavgift är 28,97 %).
 - Lösning: ta ut alla skogskontopengar före gåva, eller överlåta skogskontot till mottagaren av hela lantbruksenheten (IL 21 kap, blankett N7).
 
 ### Köp eller arv? — Skatteverkets klassificering
@@ -276,8 +276,8 @@ Ett enkelt bolag deklarerar inte själv. Var och en av delägarna tar upp sin an
 
 ### Bostadsarrende — avtalstid
 
-- Avtalstid minst **5 år** (JB 10 kap 3§). Är avtalet inte tidsbestämt eller på minst 5 år → 5 år gäller.
-- Längsta avtalstid: **50 år**.
+- Avtalstid minst **5 år** (JB 10 kap 2§). Är avtalet inte tidsbestämt eller på minst 5 år → 5 år gäller. (JB 10 kap 3§ reglerar uppsägning/förlängning.)
+- Längsta avtalstid: **50 år** (allmän nyttjanderättsgräns, JB 7 kap 5§; 25 år inom detaljplanelagt område).
 - Förlängas obegränsat antal gånger.
 - Uppsägning skriftlig, senast **1 år** före arrendetidens slut.
 - Arrendatorns förvärvsrätt: under vissa förutsättningar förtursrätt att köpa arrendestället (Lag 1985:658).

--- a/.claude/skills/swedish-jordbruk-skogsbruk/references/lantbruksfastighet.md
+++ b/.claude/skills/swedish-jordbruk-skogsbruk/references/lantbruksfastighet.md
@@ -1,0 +1,337 @@
+# Lantbruksfastighet — klassificering, generationsskifte, samägt och arrende
+
+A lantbruksenhet is normally a **mixed** fastighet from a skattesynpunkt: some parts privatbostad, some delar näringsfastighet. The split is done **per byggnad och markområde**, not per fastighet (IL 2 kap 8-13 §§).
+
+## Näringsfastighet vs privatbostad (IL 2 kap 8-13 §§)
+
+**Privatbostad**:
+- Mangårdsbyggnaden om ägaren eller någon närstående bor eller planerar att bo där (within 3 år).
+- Ett tänkt tomtområde till privatbostaden.
+- Komplementbyggnader: vedbod, pannrum, jordkällare, lekstugor, gäststugor, friggebodar, attefallshus, **Bolundare**, personbilsgarage och carport.
+
+**Näringsfastighet**:
+- Övrig produktiv skogsmark (eller med avverkningsrestriktioner)
+- Skogligt impediment
+- Åkermark, betesmark
+- Ekonomibyggnader (lagårdar, stallbyggnader, logar, lador, silor, maskinhallar, verkstadsbyggnader)
+- Bostadshus där varken ägaren eller någon närstående bor på mer än 50% av bostadsytan
+- Mangårdsbyggnader med tre eller fler lägenheter (alltid näringsfastighet)
+
+### Avsikt att bo
+
+Mangårdsbyggnaden är privatbostadsfastighet om ägaren eller närstående **planerar** att bo i huset. Tidsrymd: de närmaste 3 åren.
+
+Närståendekretsen (IL 2 kap 22§):
+- Föräldrar
+- Far- och morföräldrar
+- Make
+- Barn, barnbarn osv samt deras makar (styvbarn och fosterbarn jämställs med barn)
+- Syskon, syskons make och barn
+- Dödsbo som du eller någon av ovan nämnda personer är delägare i
+
+### Svärföräldrar — speciellt fall
+
+När två makar gemensamt äger en lantbruksfastighet och låter den ena makens föräldrar bo i mangårdsbyggnaden:
+- De boende är närstående till sitt barn, men inte till svärsonen/svärdottern.
+- För maken med sina föräldrar boende → privatbostad.
+- För maken med sina svärföräldrar boende → näringsfastighet.
+- Makarna deklarerar alltså sina andelar olika.
+
+### Slottsregeln (IL 2 kap 9§)
+
+Stor äldre mangårdsbyggnad kan på begäran behandlas som näringsfastighet **även om ägaren bor där**.
+
+Villkor:
+- Bostadsyta minst **400 kvm**.
+- Nybyggnadsåret är **före 1930**.
+- Inga krav på kulturminnesmärkning.
+
+Konsekvenser:
+- Ökade möjligheter att dra av reparations- och driftsutgifter i NV.
+- Om ägaren eller närstående bor i huset: **skattepliktig bostadsförmån** beräknas (bara för den del som verkligen utnyttjas som bostad).
+- **Kulturmiljövårdsbidrag** blir skattepliktiga.
+- Ägaren måste **varje år** ta ställning till om byggnaden ska beskattas som näringsfastighet eller privatbostadsfastighet. Knappast lönar det sig att vingla hit och dit, eftersom de senaste årens förbättringsutgifter ska återföras om byggnaden återklassificeras till privatbostad.
+- **INGET ROT-avdrag** får göras om slottsregeln tillämpas.
+
+Rättsfall:
+- Kammarrätten i Stockholm, Mål nr 3749-3751-17
+- Kammarrätten i Göteborg, Mål nr 1777-1783-14
+
+### Avskattning vid övergång näringsfastighet → privatbostad
+
+Om en näringsfastighet övergår till att bli privatbostad → **avskattning**: tidigare värdeminskningsavdrag, skogsavdrag, substansminskningsavdrag, ersättningsfond mm tas upp till beskattning i näringsverksamheten (återläggs), som om fastigheten hade sålts.
+
+### Bedömningstidpunkten + tröghetsregeln (IL 2 kap 11§)
+
+- Bedömningen görs **31 december varje år**.
+- En **2-årig** tröghetsregel: om förhållandena ändrats men byggnaden ändrar karaktär till näringsfastighet, får den fortsatt betraktas som privatbostad i ytterligare högst två år.
+
+## Räntor och fördelning
+
+Räntor som hör till mangårdsbyggnaden (privatbostad) dras av i inkomstslaget kapital med 30%-effekten.
+
+Räntor som hör till näringsfastighet och näringsverksamhet dras av direkt i NV, vilket normalt ger högre avdragseffekt (skatt+egenavgifter typiskt 40-60%).
+
+### Hur räntor ska fördelas
+
+**Huvudregeln**: efter (del)taxeringsvärdena. (IL 13 kap 8§)
+
+Example: Bostadsbyggnadsvärdet + tomtmark = 41% av hela taxeringsvärdet. → 41% av räntorna dras av i kapital, 59% i NV.
+
+**Skäliga avvikelser tillåts** om det finns substantiella skäl, t.ex. genomgripande renovering, nybyggnad, eller avverkning som ändrat värderelationen. Men man får inte "vingla" — fördelningen ska vara stabil över åren.
+
+## Solceller på lantbruk
+
+Beskattningen styrs av **var solcellerna är placerade**:
+
+### På privatbostad (mangårdsbyggnad)
+
+- Inkomstskatt: inkomst av kapital, schablonregler för småhus (40 000 kr + 20% av hyran avdrag).
+- Moms: INGEN momslyft (förbud mot momslyft på stadigvarande bostad).
+
+### På ekonomibyggnad
+
+- Inkomstskatt: inkomster räknas i NV.
+- Avskrivning av anläggningen enligt **byggnadsreglerna 4%/år** om den är avsedd att användas för byggnaden — eller enligt **inventarieregler** om den är avsedd att användas i näringsverksamheten.
+- Moms: full momslyft om all el levereras in på elnätet mot ersättning.
+
+### Skatteverkets ställningstagande dnr 131 44577-17/111
+
+Tre scenarios från Skatteverket:
+
+| Scenario | Leverans | Momslyft |
+|---|---|---|
+| All el levereras på elnätet mot ersättning | All ström för momspliktig verksamhet | 100% |
+| El levereras till både mangårdsbyggnad och ekonomibyggnad där momspliktig verksamhet bedrivs. Solcellerna på ekonomibyggnaden. Endast överskottet säljs. | El leverans till stadigvarande bostad är förbjuden | **DEL** av momsen — den som hör till ekonomibyggnaden |
+| Installerad på mangårdsbyggnad — el levereras enbart till mangårdsbyggnaden. Bara överskottet säljs. | El leverans till stadigvarande bostad | INGEN momslyft |
+
+### HFD-domen 2019
+
+Högsta förvaltningsdomstolens dom **2019-10-25, mål nr 6174-18, 6175-18 och 6177-18** rörde ingående moms på solcellsanläggningar. Med anledning av domen har Skatteverket sett över följande ställningstaganden:
+- **2018-03-01, dnr 202 90662-18/111**, Avdragsrätt för mervärdesskatt vid inköp och installation av en solcellsanläggning för mikroproduktion av el
+- **2017-12-20, dnr 202 492055-17/111**, Beskattningskonsekvenser för den som har en solcellsanläggning på sin jordbruksfastighet
+- **2017-12-20, dnr 202 492052-17/111**, Beskattningskonsekvenser för den som har en solcellsanläggning på sin villa eller fritidshus som är privatbostad
+
+### Energiskatt
+
+- Toppeffekt < 255 kW (≈30 normala villor) och ingen el överförs till elnätet → ingen energiskatt.
+- All el som överförs till elnätet → energiskatt (oftast hanterat av elhandelsföretaget som köper överskottet).
+
+## Generationsskifte
+
+### Köp vs gåva — helhetsprincipen
+
+**Helhetsprincipen** (huvudsaklighetsprincipen): En fastighetsöverlåtelse räknas i sin helhet antingen som köp (onerös transaktion) eller som gåva (benefik transaktion). Det spelar ingen roll hur parterna kallar avtalet — det är priset som avgör.
+
+**Kapitalvinsttaket** (reavinsttaket):
+- Om priset är **≥ taxeringsvärdet** → räknas som **köp**. Kapitalvinstberäkning krävs.
+- Om priset är **< taxeringsvärdet** → räknas som **gåva**. Ingen kapitalvinstberäkning.
+
+Gåvans värde = priset minskat med taxeringsvärdet **året före** överlåtelseåret.
+
+### Skattemässiga effekter
+
+**Vid köp**:
+- Mottagaren får anskaffningsvärde = priset.
+- Säljaren kapitalvinstbeskattas på hela skillnaden (med skogsavdrags-återföring etc.).
+
+**Vid gåva**:
+- Mottagaren tar över givarens **anskaffningsvärde och avskrivningsunderlag**.
+- Skogsavdragsutrymme följer med — om mottagaren övertar hela fastigheten.
+- Ingen kapitalvinst för givaren.
+
+### Lagfartskostnader
+
+- Vid köp: stämpelskatt **1.5% av priset** (eller taxeringsvärdet om det är högre, året före) + expeditionsavgift till Lantmäteriet.
+- Vid gåva: stämpelskatt slipper man, **såvida** priset är **≥ 85% av taxeringsvärdet** året före lagfart beviljas — då krävs stämpelskatt.
+
+### Lagfartskostnadens skattebehandling
+
+- Lagfartskostnaden är **inte avdragsgill** i deklarationen.
+- Lagfartskostnaden får läggas till **anskaffningsutgiften** vid kapitalvinstberäkningen vid nästa försäljning.
+- Får proportioneras på olika delarna av fastigheten — alltså ingå i avskrivningsunderlaget för ekonomibyggnader.
+- **Får ingå i underlaget för skogsavdrag endast vid rationaliseringsförvärv** (IL 21 kap 15§).
+
+### Förbehåll vid gåva
+
+Givaren kan göra förbehåll som tas in i fastighetsregistrets inskrivningsdel och gäller även om gården säljs vidare:
+- Bo kvar i ett bostadshus under viss tid eller givarens livstid
+- Ta ut viss mängd ved eller timmer ur skogen
+- Vistas på fastigheten under sommarmånaderna
+- Arrendera jorden till ett lågt pris
+- Disponera ekonomibyggnaderna
+- Behålla ett markområde för att där bygga ett annat hus
+
+Förbehåll minskar gåvans värde, vilket har betydelse för eventuell syskonrättvisa.
+
+### Specialvillkor i gåvoavtal
+
+- Fastigheten blir mottagarens **enskilda egendom** (skyddat vid äktenskapsskillnad eller bodelning vid dödsfall).
+- Fastigheten får inte säljas eller belånas inom en viss tid.
+- Barnet måste bosätta sig på fastigheten inom och/eller under en viss tid.
+
+Sådana villkor får man **endast** i gåvo- eller testamentsavtal — inte i köpeavtal.
+
+### Skogskonto vid generationsskifte
+
+- Skogskonto-medel **kan stå kvar** även om fastigheten är såld eller bortskänkt.
+- Pengarna beskattas som inkomst av (oftast passiv) NV i den takt de tas ut, av den ursprunglige innehavaren.
+- För en pensionär är detta ofta **oförmånligt** (24.26% löneskatt istället för 10.21% egenavgifter).
+- Lösning: ta ut alla skogskontopengar före gåva, eller överlåta skogskontot till mottagaren av hela lantbruksenheten (IL 21 kap, blankett N7).
+
+### Köp eller arv? — Skatteverkets klassificering
+
+| Situation | Klassificering |
+|---|---|
+| Arvinge tillskiftas skogsfastigheten vid arvskiftet | Hela fastigheten = **arv** |
+| Arvinge löser ut alla andra dödsbodelägare och betalar arvskifteslikvid | Hela fastigheten = **arv** (även om det rubriceras som köp) |
+| Arvinge köper fastigheten av dödsbo där hen är delägare, INTE i samband med arvskifte | Andelen som motsvarar dödsboandelen = arv; resten = köp |
+| Efterlevande make tillskiftas i bodelning, säljer sedan vidare till annan dödsbodelägare | Bedöms som arv per punkt 3 (skatteflyktslagen tillämpas på upplägget) |
+| Arvinge tillskiftas, säljer till make under kapitalvinsttaket | Godkänns som rent köp |
+
+## Samägt och dödsboägt lantbruk
+
+### Två personer — enkelt bolag
+
+Om två eller flera personer tillsammans äger en fastighet taxerad som lantbruksenhet, betraktas driften som ett **enkelt bolag** (om inte delägarna kommit överens om annat).
+
+- Var och en har sin enskilda näringsverksamhet.
+- Var och en ansvarar för sina skulder och äger sina tillgångar.
+- Det finns inget som hindrar att de har sin andel av en gemensam tillgång eller var sin andel av visst lån.
+- Kvitton och avtal skrivs ordentligt så att det syns vem som äger vad.
+
+Två makar kan driva ett lantbruk tillsammans och skattemässigt dela på resultatet i deklarationerna. Båda lämnar blankett NE som bilaga, eller en make lämnar NE och en make lämnar NEA.
+
+### Fler än två personer
+
+**Ställföreträdare** (Lag 1989:31 om förvaltning av vissa samägda jordbruksfastigheter):
+- Om fastighet ägs av minst **3 personer** måste de utse ställföreträdare.
+- Ställföreträdaren utses genom **majoritetsbeslut**. Varje delägare har röster i förhållande till sin andel.
+- Vid lika röstetal: lottning.
+- **Anmälan till Lantmäteriet** på särskild blankett.
+- Ställföreträdaren får inte sälja, inteckna eller pantsätta fastigheten, eller upplåta nyttjanderätt (exempelvis arrende) om avtalet gäller längre tid än fem år eller för någons livstid.
+
+Om delägarna inte kommer överens finns bara en utväg: **begära att fastigheten säljs på offentlig auktion** (Hovrätten för Nedre Norrland 2010-10-27, Mål nr ÖÄ 698-10).
+
+### Försäljning på offentlig auktion
+
+- Ansökan hos tingsrätten.
+- Tingsrätten utser en god man som ombesörjer auktionen, fördelar köpeskillingen och utfärdar köpebrev.
+- Lägsta pris får inte sättas så lågt att en kapitalstarkare delägare kan ropa in fastigheten till lågt pris. Får heller inte sättas så högt att försäljningen riskerar att inte komma till stånd.
+- Anstånd kan beviljas om en delägare har särskilda skäl (t.ex. sociala skäl — bott hela sitt liv där).
+
+### Dödsboägt lantbruk — 4-årsfristen
+
+Om en fastighet taxerad som lantbruksenhet ingår i ett dödsbo, ska boet ha **avvecklat fastighetsinnehavet senast 4 år efter slutet av det kalenderår då dödsfallet inträffade** (Ärvdabalk 18 kap 7§).
+
+Detta gäller **även dödsbon med endast en enda delägare** (NJA 1999 s 220).
+
+Länsstyrelsen har tillsyn — om avvecklingen inte gjorts inom föreskriven tid kan länsstyrelsen vid vite förelägga dödsboet att fullgöra sin skyldighet. Anstånd kan medges vid särskilda skäl.
+
+### Avveckling
+
+Sätten att avveckla:
+1. Dödsboet säljer fastigheten till en dödsbodelägare eller utomstående.
+2. Bodelning eller arvskifte, så att en eller flera dödsbodelägare äger andelar.
+3. Samtliga dödsbodelägare äger fastigheten gemensamt (förutsatt att de är fler än två → ställföreträdare måste utses).
+
+### Deklaration — enkelt bolag
+
+Ett enkelt bolag deklarerar inte själv. Var och en av delägarna tar upp sin andel.
+
+**Representantredovisning** (vanligt vid enkelt bolag):
+- En delägare utses som representant.
+- Representanten redovisar samtliga inkomster, utgifter, avskrivningar och justeringar på blankett NE.
+- Representanten får fram det enkla bolagets samlade resultat i ruta R17. Drar av övrigas andel i ruta R18. Fyller i resten med egna uppgifter.
+- Övriga delägare redovisar endast sin del av resultatet vid ruta R21 och fyller i resten av blanketten med sina egna uppgifter.
+- Personnumret på den redovisningsansvarige för det enkla bolaget anges på sid 1.
+
+### Representantredovisning — moms och uppbörd
+
+- Bolaget registrerar en representant och får ett särskilt registreringsnummer från Skatteverket. Detta registreringsnummer används vid redovisning av moms och uppbörd för det enkla bolaget, kopplat till ett skattekonto.
+- Momsen redovisas i representantens skattedeklarationer.
+- Övriga delägare redovisar ingen moms.
+- Delägarna är fortfarande **solidariskt ansvariga** — om representanten inte sköter redovisningen kan Skatteverket kräva att var och en av delägarna ska redovisa och betala sin andel.
+
+## Arrende
+
+**Skogsarrende** is **inte** en arrendeform — det är en *avverkningsrätt*. Behandlas under skogsbeskattning.
+
+### Jordbruksarrende — jordägarens perspektiv
+
+**Inkomstdeklaration**: jordägaren deklarerar fastigheten som **passiv NV** när jordbruket är utarrenderat (såvida inte exempelvis skogsbruket bedrivs själv ≥500-600 timmar/år, eller om jordägaren bedriver helt annan verksamhet).
+
+**Inkomster**: arrendeinkomster (inkl. jaktarrende), ränteinkomster på bankmedel.
+**Kostnader**: räntor på lån, avskrivningar och reparationer på byggnader, markanläggningar och inventarier.
+
+**Bostadsbyggnaden**: är privatbostad om ägaren eller någon närstående bor i den. Om byggnaden bebos av en arrendator eller hyresgäst eller anställd personal som inte är närstående → näringsfastighet. Jordägaren får då full avdragsrätt för bostadshuset, men ska inte skatta för någon bostadsförmån.
+
+**Arrende till närstående**: Arrenderar du ut hela fastigheten till någon av dina barn som tagit över driften i mangårdsbyggnaden, betraktas denna som privatbostad **för din del**. Den del av arrendet som hör till bostadsbyggnaden tar du upp som inkomst i inkomstslaget **kapital**, uthyrning av privatbostad.
+
+**Engångsersättning** (övergångsersättning): Periodiseras över avtalstiden. En engångsersättning för ett arrende med löptid 25 år tas upp som intäkt med 1/25 varje år. Periodiseringen beror på att arrendeavtalet ska uppfyllas successivt (RÅ 2002 ref 84).
+
+**Obegränsad tid → allframtidsupplåtelse**: Är arrendet på obegränsad tid är engångsersättningen en allframtidsupplåtelse (kapitalvinstreglerna).
+
+**Arrendatorns förbättringar**: När arrendet upphör beskattas jordägaren för värdeökningen från arrendatorns förbättringar av byggnader och markanläggningar. Avskrivningsunderlaget ökas med samma belopp.
+
+### Jordbruksarrende — arrendatorns perspektiv
+
+- **NV**: hela arrenderätten redovisas i inkomstslaget NV även om arrendatorn inte själv äger fastigheten.
+- **Moms**: 25% på jordbruksarrende. Också 25% på jakt- och fiskearrende.
+- **Bostadsbyggnaden** i arrendet: arrendatorn skattar **inte** för bostadsförmån eftersom mangårdsbyggnaden inte ingår i hens NV. Men arrendatorn får INTE dra av den del av arrendeavgiften som motsvarar bostadshuset.
+- **Specialregel — momslyft på bostadsdelen**: Trots det får arrendatorn **lyfta hela momsen** på arrendet, även om värdet av bostad ingår i arrendet.
+- **Förbättringar**: får göra värdeminskningsavdrag på byggnader och täckdiken med **5%** av hela anskaffningsutgiften. Täckdiken (och vissa skogsvägar) skrivs av med **10%**.
+- Om arrendet upphör innan tillgångarna är helt avskrivna → arrendatorn får dra av oavskrivet värde.
+- Tillfälliga byggnader eller markanläggningar som bara används ett fåtal år → direktavdrag samma år som de uppförs.
+
+### Besittningsskydd
+
+- **Jordbruksarrende**: starkt besittningsskydd. Arrendatorn har normalt rätt till **förlängning** även om jordägaren säger upp avtalet. Undantag: självinträde — jordägaren eller närstående aktivt brukar fastigheten själv.
+- **Bostadsarrende**: i de flesta fall förlängningsrätt. Om parterna inte kommer överens → arrendenämnden fastställer nya villkor (ny arrendeavgift, ny arrendetid).
+
+### Bostadsarrende — avtalstid
+
+- Avtalstid minst **5 år** (JB 10 kap 3§). Är avtalet inte tidsbestämt eller på minst 5 år → 5 år gäller.
+- Längsta avtalstid: **50 år**.
+- Förlängas obegränsat antal gånger.
+- Uppsägning skriftlig, senast **1 år** före arrendetidens slut.
+- Arrendatorns förvärvsrätt: under vissa förutsättningar förtursrätt att köpa arrendestället (Lag 1985:658).
+
+### Överlåtelse av arrenderätten
+
+- För bostadsarrende: arrendatorn får överlåta till någon "med vilken jordägaren skäligen kan nöjas". Måste först erbjuda jordägaren att återta arrendestället mot rimlig ersättning (JB 10 kap 7§).
+- Ersättning vid överlåtelse är **inkomst i NV** för upplåtaren.
+
+## BAS-mapping for lantbruksfastighet
+
+| Konto | Användning |
+|---|---|
+| 1110 | Byggnader (näringsfastighet ekonomibyggnader) |
+| 1130 | Mark |
+| 1135 | Skogsmark (lantbruks-specifik) |
+| 1140 | Stenbrott och täkter (om aktuellt) |
+| 1150 | Markanläggningar |
+| 1158 | Skogsvägar (ackumulerade avskrivningar) |
+| 1159 | Täckdiken (ackumulerade avskrivningar) |
+| 1180 | Pågående nyanläggningar |
+| 1220 | Inventarier och verktyg |
+| 1230 | Maskiner i jordbruket |
+| 1240 | Bilar och andra transportmedel |
+| 1280 | Pågående nyanläggningar och förskott på maskiner |
+| 1410 | Lager av råvaror |
+| 1430 | Lager av djur i jordbruk |
+| 1460 | Lager av skogsprodukter |
+| 1465 | Lager av virke (vid bilväg) |
+| 1469 | Inkuransavdrag 3% (5 070, lägre för djur 15%) |
+| 7820 | Avskrivningar markanläggningar/substansminskning |
+| 7821 | Avskrivningar byggnader |
+| 7832 | Avskrivningar inventarier |
+
+(LRF-BAS har egna lantbruksspecifika konton — denna lista är generell BAS.)
+
+## Cross-references
+
+- For skogsavdrag mechanics: `skogsbeskattning.md`
+- For substansminskningsavdrag: `naturtillgangar-och-upplatelser.md`
+- For djur som lager + inventarie-specifika regler: `bokforing-och-blanketter.md`
+- For förvärvstillstånd, jordförvärvslagen: outside this skill's scope (legal compliance, not skatte)

--- a/.claude/skills/swedish-jordbruk-skogsbruk/references/lantbruksfastighet.md
+++ b/.claude/skills/swedish-jordbruk-skogsbruk/references/lantbruksfastighet.md
@@ -9,6 +9,8 @@ A lantbruksenhet is normally a **mixed** fastighet from a skattesynpunkt: some p
 - Ett tänkt tomtområde till privatbostaden.
 - Komplementbyggnader: vedbod, pannrum, jordkällare, lekstugor, gäststugor, friggebodar, attefallshus, **Bolundare**, personbilsgarage och carport.
 
+> **Terminologi-uppdatering (PBL 2025-12-01):** Friggebod och attefallshus har via PBL-reformen 2025 slagits ihop till en samlad kategori "**komplementbyggnad**" (max 30 kvm inom detaljplan, 50 kvm utanför; sammanlagd potten 45 / 65 kvm). Detta är **byggrätt, inte skatterätt** — påverkar inte direkt privatbostads-/näringsfastighetsklassificeringen, men termen "Bolundare" och "attefallshus" är inte längre officiella i bygglagstiftningen. Skatteverket använder fortfarande de gamla termerna när IL 2 kap tolkas, så listan ovan gäller alltjämt skattemässigt.
+
 **Näringsfastighet**:
 - Övrig produktiv skogsmark (eller med avverkningsrestriktioner)
 - Skogligt impediment
@@ -80,37 +82,20 @@ Example: Bostadsbyggnadsvärdet + tomtmark = 41% av hela taxeringsvärdet. → 4
 
 **Skäliga avvikelser tillåts** om det finns substantiella skäl, t.ex. genomgripande renovering, nybyggnad, eller avverkning som ändrat värderelationen. Men man får inte "vingla" — fördelningen ska vara stabil över åren.
 
-## Solceller på lantbruk
+## Solceller på lantbruk — fastighetsklassificeringens effekt
 
-Beskattningen styrs av **var solcellerna är placerade**:
+Solcellsanläggningens skattekonsekvenser styrs primärt av **var den är placerad** och **vilken byggnadstyp den försörjer**:
 
-### På privatbostad (mangårdsbyggnad)
+| Placering / leverans | Inkomstslag | Momslyft | Grönt avdrag |
+|---|---|---|---|
+| På mangårdsbyggnad (privatbostad), försörjer endast småhuset | Kapital (schablon) | Inget (förbud stadigvarande bostad) | Ja, **kräver två elabonnemang** |
+| På ekonomibyggnad, försörjer endast näringsverksamheten | NV | Fullt momslyft | Nej (näringsfastighet) |
+| Blandad försörjning (både småhus och ekonomibyggnad/näringsdel) | NV för näringsdelen | Proportionerligt — del som hör till ekonomibyggnaden | **Nej** för småhusdelen utan separat elmätning |
+| All el säljs in på elnätet mot ersättning | NV | 100 % | Nej |
 
-- Inkomstskatt: inkomst av kapital, schablonregler för småhus (40 000 kr + 20% av hyran avdrag).
-- Moms: INGEN momslyft (förbud mot momslyft på stadigvarande bostad).
+**Avskrivning på näringsfastighet**: anläggningen avskrivs som byggnadsinventarium (oftast 20 % årligt restvärde eller 30 %/20 % räkenskapsenligt) om den är funktionellt avskild från byggnaden — eller med byggnadens 4 %/år-sats om den är integrerad. Bedöms från fall till fall.
 
-### På ekonomibyggnad
-
-- Inkomstskatt: inkomster räknas i NV.
-- Avskrivning av anläggningen enligt **byggnadsreglerna 4%/år** om den är avsedd att användas för byggnaden — eller enligt **inventarieregler** om den är avsedd att användas i näringsverksamheten.
-- Moms: full momslyft om all el levereras in på elnätet mot ersättning.
-
-### Skatteverkets ställningstagande dnr 131 44577-17/111
-
-Tre scenarios från Skatteverket:
-
-| Scenario | Leverans | Momslyft |
-|---|---|---|
-| All el levereras på elnätet mot ersättning | All ström för momspliktig verksamhet | 100% |
-| El levereras till både mangårdsbyggnad och ekonomibyggnad där momspliktig verksamhet bedrivs. Solcellerna på ekonomibyggnaden. Endast överskottet säljs. | El leverans till stadigvarande bostad är förbjuden | **DEL** av momsen — den som hör till ekonomibyggnaden |
-| Installerad på mangårdsbyggnad — el levereras enbart till mangårdsbyggnaden. Bara överskottet säljs. | El leverans till stadigvarande bostad | INGEN momslyft |
-
-### HFD-domen 2019
-
-Högsta förvaltningsdomstolens dom **2019-10-25, mål nr 6174-18, 6175-18 och 6177-18** rörde ingående moms på solcellsanläggningar. Med anledning av domen har Skatteverket sett över följande ställningstaganden:
-- **2018-03-01, dnr 202 90662-18/111**, Avdragsrätt för mervärdesskatt vid inköp och installation av en solcellsanläggning för mikroproduktion av el
-- **2017-12-20, dnr 202 492055-17/111**, Beskattningskonsekvenser för den som har en solcellsanläggning på sin jordbruksfastighet
-- **2017-12-20, dnr 202 492052-17/111**, Beskattningskonsekvenser för den som har en solcellsanläggning på sin villa eller fritidshus som är privatbostad
+För detaljer om momslyft-mekaniken, HFD 2019-domens innebörd, status på Skatteverkets ställningstaganden (dnr 131 44577-17/111 m.fl.), två-elabonnemang-kravet för grönt avdrag, 5 %-schablonens upphörande 2024-03-22, samt slopandet av 60-öres-skattereduktionen 2026-01-01 → se `lantbruks-moms.md` sektion "Solceller på lantbruk — moms".
 
 ### Energiskatt
 
@@ -127,7 +112,7 @@ Högsta förvaltningsdomstolens dom **2019-10-25, mål nr 6174-18, 6175-18 och 6
 - Om priset är **≥ taxeringsvärdet** → räknas som **köp**. Kapitalvinstberäkning krävs.
 - Om priset är **< taxeringsvärdet** → räknas som **gåva**. Ingen kapitalvinstberäkning.
 
-Gåvans värde = priset minskat med taxeringsvärdet **året före** överlåtelseåret.
+Gåvomomentets värde = **taxeringsvärdet** (eller marknadsvärdet) **året före** överlåtelseåret minus **vederlaget** (priset). När vederlaget är 0 är hela fastighetens taxeringsvärde gåva; när vederlaget är ≥ taxeringsvärdet är gåvomomentet 0 och hela överlåtelsen ses som köp. Stämpelskattens 85 %-gräns jämför vederlaget med taxeringsvärdet året före.
 
 ### Skattemässiga effekter
 
@@ -176,7 +161,7 @@ Sådana villkor får man **endast** i gåvo- eller testamentsavtal — inte i k�
 
 - Skogskonto-medel **kan stå kvar** även om fastigheten är såld eller bortskänkt.
 - Pengarna beskattas som inkomst av (oftast passiv) NV i den takt de tas ut, av den ursprunglige innehavaren.
-- För en pensionär är detta ofta **oförmånligt** (24.26% löneskatt istället för 10.21% egenavgifter).
+- För en pensionär är detta ofta **oförmånligt** (24,26 % särskild löneskatt enligt SLF, lag 1990:659, i stället för 10,21 % egenavgifter).
 - Lösning: ta ut alla skogskontopengar före gåva, eller överlåta skogskontot till mottagaren av hela lantbruksenheten (IL 21 kap, blankett N7).
 
 ### Köp eller arv? — Skatteverkets klassificering

--- a/.claude/skills/swedish-jordbruk-skogsbruk/references/naturtillgangar-och-upplatelser.md
+++ b/.claude/skills/swedish-jordbruk-skogsbruk/references/naturtillgangar-och-upplatelser.md
@@ -138,11 +138,13 @@ För allframtidsupplåtelse finns bara **en** metod (motsvarande metod 2 vid del
 
 ### Bagatellersättningar (IL 45 kap 24§)
 
-För att inte små belopp ska beskattas: schablonmässigt **omkostnadsbelopp 5 000 kr per år** får dras av, oavsett hur många upplåtelser man gjort under året. Frivillig metod.
+För att inte små belopp ska beskattas: schablonmässigt **omkostnadsbelopp 12 000 kr per år** (höjt från 5 000 kr fr.o.m. 2024-01-01) får dras av, oavsett hur många upplåtelser man gjort under året. Frivillig metod.
 
 **Begränsningar**:
-- Schablonen 5 000 kr får inte överstiga ersättningen — inte avdragsgill förlust.
+- Schablonen 12 000 kr får inte överstiga ersättningen — inte avdragsgill förlust.
 - Gäller bara inkomster som **kapitalvinstredovisas**, inte inkomster som tas upp i näringsverksamheten.
+
+Den separata skattefrihetsgränsen för kontant engångsersättning vid allframtidsupplåtelse (IL 45 kap 5§) höjdes samtidigt från 5 000 kr till **42 000 kr** per år.
 
 ### Begränsad tid — då INTE kapitalvinst
 

--- a/.claude/skills/swedish-jordbruk-skogsbruk/references/naturtillgangar-och-upplatelser.md
+++ b/.claude/skills/swedish-jordbruk-skogsbruk/references/naturtillgangar-och-upplatelser.md
@@ -1,0 +1,240 @@
+# Naturtillgångar, delavyttring och allframtidsupplåtelser
+
+Three closely-related capital-event categories that often appear together on lantbruksenheter when a road, kraftledning, vindkraftverk eller täkt påverkar fastigheten.
+
+## Substansminskningsavdrag (IL 20 kap)
+
+Vid utvinning av naturtillgångar (typically **grus-, sand-, berg-, torv-täkter**) får fastighetsägaren avdrag baserat på anskaffningsutgiften för naturtillgången — på samma sätt som skogsavdrag.
+
+### Anskaffningsvärdet — three methods
+
+**Huvudregeln**: vad köparen betalt för täkten (om köpt separat) eller proportionering efter taxeringsvärdet om täkten ingår i en fastighet.
+
+Example: Lantbruksfastighet köpt för 1 200 000 kr. Totalt taxeringsvärde 800 000 kr varav grustäkten 200 000 kr (efter exploateringen utbryts täkten till en självständig fastighet med taxeringsvärde 200 000 kr).
+
+Anskaffningsvärde för täkten = 200 000 / 800 000 × 1 200 000 = **300 000 kr**.
+
+**Alternativregeln** (schablonregel om täktområdet inte hade något eget taxeringsvärde): Beräkningsmetoden är **70% av täkthrens marknadsvärde vid utvinningens början, multiplicerat med 75%-spärren av marknadsvärdet**, dvs i praktiken det belopp som motsvarar **75% av täktmarkens marknadsvärde** vid utvinningens början.
+
+Exploateringskostnader (det som inte dragits av i löpande drift) får läggas till anskaffningsvärdet, även efter exploateringens början.
+
+Återställningskostnader enligt naturvårdslagen får läggas till anskaffningsvärdet. För den som gör förenklat årsbokslut: får inte göra avsättning, men får lägga beräknade återställningskostnader till anskaffningsvärdet (eller upprätta vanligt årsbokslut).
+
+### Avdragsberäkning
+
+För visst beskattningsår: max belopp = (anskaffningsvärde för hela tillgången) × (totalt uttagen mängd t.o.m. beskattningsåret / total mängd i tillgången), minskat med tidigare gjorda avdrag.
+
+Avdrag får INTE göras i snabbare takt än faktiska uttaget. Däremot får faktiskt uttag *förskjutas* till senare år om man inte utnyttjat det visst år.
+
+### Worked example
+
+Grustäkt på lantbruksfastighet. Vid anskaffningen 10 000 m³ grus. Anskaffningsvärde 200 000 kr.
+
+År 2016-2019: utvunnit 4 000 m³. Avdrag gjorda 70 000 kr (men hade kunnat vara 4 000/10 000 × 200 000 = 80 000 kr).
+
+2020: utvinning 1 000 m³.
+- Totalt utvunnit 5 000 m³ av 10 000.
+- Totalt tillåtet avdrag t.o.m. 2020 = 5 000/10 000 × 200 000 = **100 000 kr**.
+- Tidigare gjorda avdrag = 70 000 kr.
+- Högsta avdrag för 2020 = 100 000 − 70 000 = **30 000 kr**.
+
+### Avdrag för förskottsersättning
+
+Vid förskott på upplåten utvinningsrätt: avsättning kan göras i räkenskaperna (vanligt årsbokslut). Avsättningen återförs till beskattning påföljande beskattningsår och matchas mot verklig substansminskning.
+
+Förskottet får inte ge ett högre avdrag än det belopp som motsvarar den del av anskaffningsvärdet som kan anses höra till den framtida utvinning som förskottsbetalningen avser.
+
+### BAS-konton
+
+| Konto | Användning |
+|---|---|
+| 1140 | Mark (anläggningstillgång) |
+| 1149 | Ackumulerade nedskrivningar mark (substansminskning) |
+| 7820 | Avskrivningar/substansminskning på mark |
+
+## Delavyttring (IL 45 kap)
+
+När man säljer **en del av en fastighet** istället för hela. Vid skogsfastigheter är detta vanligt — man styckar av en tomt eller ett mindre område och säljer.
+
+### Avstyckning vs ideell andel
+
+- **Avstyckning** (försäljning av visst markområde) → delavyttring → kan välja mellan metoderna nedan.
+- **Försäljning av ideell andel** (kvotdel) i en fastighet → INTE delavyttring → vanlig kapitalvinstberäkning enligt fastighetsförsäljningsreglerna (RÅ 1986 ref 110).
+
+### Återläggning av skogsavdrag och värdeminskning
+
+Vid försäljning av del av näringsfastighet ska skogsavdrag och andra värdeminskningsavdrag som hör till **den sålda fastighetsdelen** återföras. Detta gäller oavsett vilken metod som väljs (IL 26 kap 7§).
+
+För värdeminskningsavdrag på t.ex. byggnad: byggnaden måste ligga på den avyttrade fastighetsdelen för att återläggning ska ske.
+
+### 5 000-kronorsgränsen för förbättringar (IL 45 kap 19§)
+
+Vid privatbostadsfastighet finns en gräns: avdrag för förbättringsutgifter får endast göras om utgifterna under ett visst år varit minst 5 000 kr.
+
+Vid delavyttring finns en särskild regel: hela fastigheten ska bedömas, inte bara den avyttrade delen. Sedan beräknas avdragets storlek utifrån förhållandena på den avyttrade fastighetsdelen.
+
+### Konsumering av omkostnadsbelopp
+
+När en del av fastigheten säljs och omkostnadsbelopp använts vid kapitalvinstberäkningen, ska detta belopp **minska omkostnadsbeloppet** vid slutförsäljning av resten — ett slags uppskov.
+
+### Metod 1 — proportionering med hjälp av taxeringsvärdet (IL 45 kap 19§)
+
+Förhållandena för **den sålda delen** används.
+
+Worked example:
+- Lantbruksfastighet med totalt köpeskilling 130 000 kr, taxeringsvärde 120 000 kr (varav mark 15 000 + byggnad 105 000).
+- Tomten som styckas av: 1 000 kvm av total 2 500 kvm.
+- Försäljningspris för tomten: 80 000 kr.
+- Tomtens taxeringsvärde har egentligen aldrig fastställts separat.
+- Skattaverket bestämmer normalt en höjning på den avstyckade tomten med 30 000 kr (vilket har betydelse vid metod 2).
+
+Omkostnadsbelopp för marken med metod 1: 15 000/120 000 × 130 000 = 16 250 kr.
+Omkostnadsbelopp för den avstyckade delen: 1 000/2 500 × 16 250 = **6 500 kr**.
+
+Kapitalvinst = 80 000 − 6 500 = 73 500 kr.
+
+**Metod 1 fungerar bäst för privatbostadsfastighet.** För lantbruk blir det besvärligare.
+
+### Metod 2 — värderelationer vid avyttringen (IL 45 kap 20§)
+
+Omkostnadsbeloppet för den sålda fastighetsdelen = (försäljningspris för delen / hela fastighetens värde vid försäljningen) × omkostnadsbelopp för hela fastigheten.
+
+Worked example (skog):
+- Skogsfastighet köpt för 160 000 kr.
+- Taxeringsvärde för skogsskiftet 240 000 kr, för tomten 60 000 kr, totalt 300 000 kr.
+- Marknadsvärde = 300 000 × 1.33 = 400 000 kr.
+- Pris på den sålda tomten = 80 000 kr = 20% av hela fastighetens värde.
+- Omkostnadsbelopp för avstyckade delen = 20% × 160 000 = 32 000 kr.
+- Kapitalvinst = 80 000 − 32 000 = **48 000 kr**.
+
+**Metod 2 fungerar bäst när taxeringsvärden är dåligt anpassade till värdeförhållandena.**
+
+### Metod 3 — schablonregel för små tomter (IL 45 kap 21§)
+
+Endast tillämplig om:
+- Den sålda fastighetsdelen är en eller ett fåtal tomter avsedda för bostadsbygge.
+- Priset är **mindre än 10% av fastighetens taxeringsvärde**.
+
+Då får schablonmässigt beräknas omkostnadsbeloppet till **1 krona per kvadratmeter**.
+
+Omkostnadsbeloppet får inte överstiga priset på den sålda delen — alltså aldrig avdragsgill förlust enligt metod 3.
+
+## Allframtidsupplåtelser (IL 45 kap 6-7§§)
+
+En allframtidsupplåtelse är en **inskränkning för obegränsad tid** av förfoganderätten till en fastighet, eller upplåtelse av nyttjanderätt/servitut för obegränsad tid. Skattemässigt **likställd med fastighetsförsäljning** — kapitalvinstberäknas.
+
+### Vanligast på lantbruksfastighet
+
+- Kraftledningar
+- Järnvägar
+- Allmänna och enskilda vägar
+- Vindkraftverk (NB: dessa är oftast för begränsad tid och då **INTE** allframtidsupplåtelser)
+- Inrättande av naturvårdsområde, naturreservat eller djur- och växtskyddsområde
+- Uppdämning av vatten (vattenkraftverk)
+
+### Kapitalvinstberäkning — endast metod 2
+
+För allframtidsupplåtelse finns bara **en** metod (motsvarande metod 2 vid delavyttring): omkostnadsbeloppet = (likvid för upplåtelsen / hela fastighetens värde vid upplåtelsen) × omkostnadsbeloppet för hela fastigheten.
+
+### Bagatellersättningar (IL 45 kap 24§)
+
+För att inte små belopp ska beskattas: schablonmässigt **omkostnadsbelopp 5 000 kr per år** får dras av, oavsett hur många upplåtelser man gjort under året. Frivillig metod.
+
+**Begränsningar**:
+- Schablonen 5 000 kr får inte överstiga ersättningen — inte avdragsgill förlust.
+- Gäller bara inkomster som **kapitalvinstredovisas**, inte inkomster som tas upp i näringsverksamheten.
+
+### Begränsad tid — då INTE kapitalvinst
+
+Ersättning för markupplåtelse för **begränsad tid** beskattas **inte** enligt kapitalvinstreglerna utan i näringsverksamheten. Engångsersättning för t.ex. vindkraftverk över 25 år ska periodiseras (RÅ 2002 ref 84).
+
+### Försäljning av skog i samband med allframtidsupplåtelse
+
+Ersättning för skog (träden) som finns på den upplåtna marken kan helt eller delvis beskattas enligt kapitalvinstreglerna ihop med markupplåtelsen.
+
+Om man tar hand om virkesförsäljningen separat (egen avverkning eller via avverkningsrätt): **valfrihet** mellan att beskatta som kapitalvinst eller i näringsverksamheten.
+
+För ålderspensionärer (låga egenavgifter + förstärkt jobbskatteavdrag) kan totala skatten bli lägre om inkomsten beskattas i näringsverksamheten istället för kapital. Räkna båda vägarna.
+
+### Vid kapitalvinstvägen — endast rotvärdet
+
+Om man väljer att kapitalvinstbeskatta virkesförsäljning i samband med allframtidsupplåtelse:
+- Vid försäljning av avverkningsrätt: hela köpeskillingen kapitalvinstbeskattas.
+- Vid egen avverkning: endast **60% av leveransvirkets köpeskilling** kapitalvinstbeskattas. Resten tas upp som intäkt i NV samtidigt som avverkningskostnader dras av där.
+
+Skälet är att 40% av leveransvirkesintäkten anses motsvara värdet av arbetet, vilket inte tillhör fastighetens omkostnad.
+
+### Momsen
+
+Säljs virket separat ska moms redovisas på skogslikviden, oavsett om man kapitalvinstbeskattar inkomsten eller beskattar den i näringsverksamheten. Detta gör att bokföringsprogrammets momsrapport inte kommer att stämma — manuell justering nödvändig.
+
+### Räntekompensation
+
+När uppgörelser drar ut på tiden, brukar upplåtaren få ränta. Räntan beskattas i samma inkomstslag som ersättningen den hör till:
+- Räntor till ersättningar som kapitalvinstbeskattas → kapital
+- Räntor till ersättningar som beskattas i NV → NV
+
+### Bestående vs tillfällig skada
+
+Detta är ofta en svår avvägning vid skadeersättningar:
+
+| Ersättning för | Beskattning |
+|---|---|
+| Intrångsersättningar (ändrat avstånd, passagehinder av väg, fältkantverkan, försvårat bete, brukningsintrång) | Kapitalvinst |
+| Mark | Kapitalvinst |
+| Fördyrad avverkning, tillfällig skada | Näringsverksamhet |
+| Fördyrad avverkning, bestående skada | Kapitalvinst |
+| Skogsskada | Kapitalvinst |
+| Virke eller avverkningsrätt | Valfritt |
+| Förtidig avverkning | Valfritt |
+| Förstörd gröda | Näringsverksamhet |
+| Miljöskador (intrång, utsikt mm) | Kapitalvinst |
+| Byggnad (ersättning av värdet, återuppförande, flyttning, rivning, framtida skador på vatten mm) | Kapitalvinst |
+| Byggnadsinventarier | Näringsverksamhet |
+| Stängsel (engångsuppsättning, flyttning) | Näringsverksamhet |
+| Stängsel (förnyelse och underhåll) | Kapitalvinst |
+
+### Kompensation för frivillig uppgörelse
+
+Specialersättning till markägare för att hen frivilligt går med på upplåtelsen ska beskattas enligt samma regler som de underliggande ersättningarna — om de underliggande är 70% kapitalvinst och 30% NV, så fördelas kompensationen 70/30.
+
+### Skattefria ersättningar
+
+Två rättsfall ger fastighetsägare rätt till **skattefri** ersättning:
+- **RÅ 2008 ref 87**: Förstörd utsikt som kommunen ersatte fastighetsägaren för. Inte allframtidsupplåtelse, inte avkastningsförlust → skattefritt.
+- **Regeringsrätten mål nr 3754-3755-06**: Vägverkets utbetalda ersättning för bullerstörningar. Ej allframtidsupplåtelse → skattefritt.
+
+## Worked example — kombinerad allframtidsupplåtelse + virkesförsäljning
+
+Två bröder, Albert och Herbert, köpte ett skogsskifte tillsammans (hälften vardera) för 400 000 kr. Inga skogsavdrag har gjorts.
+
+I samband med byggandet av Mälarbanan får bröderna **60 000 kr** för upplåtelse av mark. I uppgörelsen ingår att bröderna själva får ta hand om virket på den upplåtna marken. De säljer timmer och massaved för **40 000 kr** samma år som de får inlösenbeloppet.
+
+Hela fastigheten värderas vid upplåtelsen till **600 000 kr**.
+
+**Herbert** har ett inrullat underskott i sin näringsverksamhet (hjortuppfödning som gått med förlust). Han väljer att redovisa hela sin andel av virkesförsäljningen (20 000 kr) i näringsverksamheten.
+
+**Albert** väljer att kapitalvinstbeskatta så mycket som möjligt:
+
+Upplåtelseersättning 50% × 60 000 = 30 000 kr
+Virkesförsäljning kapitalvinst 60% × 50% × 40 000 = 12 000 kr
+Sammanlagt vid kapitalvinstberäkningen = **42 000 kr**
+
+Resterande del av virkesförsäljningen beskattas i NV: 40% × 50% × 40 000 = 8 000 kr.
+
+Kapitalvinstberäkningen för Albert:
+- Likvid för upplåtelse + skog = 42 000 kr
+- Omkostnadsbelopp 42 000/600 000 × 400 000 = **−28 000 kr** (proportionering efter värdet)
+- Kapitalvinst = 14 000 kr
+
+Skatt:
+- Skattepliktig del 90% × 14 000 = 12 600 kr (för näringsfastighet)
+- Skatt på kapitalvinst 30% × 12 600 = 3 780 kr
+- Skatt + egenavgifter på NV-delen 50% × 8 000 = 4 000 kr
+- Sammanlagd skatt på ersättningen 50 000 kr = **7 780 kr** = ca 15.6% effective rate.
+
+## Cross-references
+
+- Allmänna kapitalvinstregler för fastighet: **swedish-financial-reporting** (K5/K7-blanketter)
+- Momsen på skogsprodukter: **swedish-vat** (allmänt) + `lantbruks-moms.md` (lantbruksspecifika undantag)
+- Ackumulerad inkomst vid stora kapitalvinster: IL 66 kap (mer än 50 000 kr extra, minst 2 år) — kan jämna ut den statliga skatten.

--- a/.claude/skills/swedish-jordbruk-skogsbruk/references/naturtillgangar-och-upplatelser.md
+++ b/.claude/skills/swedish-jordbruk-skogsbruk/references/naturtillgangar-och-upplatelser.md
@@ -14,7 +14,7 @@ Example: Lantbruksfastighet köpt för 1 200 000 kr. Totalt taxeringsvärde 800 
 
 Anskaffningsvärde för täkten = 200 000 / 800 000 × 1 200 000 = **300 000 kr**.
 
-**Alternativregeln** (schablonregel om täktområdet inte hade något eget taxeringsvärde): Beräkningsmetoden är **70% av täkthrens marknadsvärde vid utvinningens början, multiplicerat med 75%-spärren av marknadsvärdet**, dvs i praktiken det belopp som motsvarar **75% av täktmarkens marknadsvärde** vid utvinningens början.
+**Alternativregeln** (schablonregel om täktområdet inte hade något eget taxeringsvärde): Anskaffningsvärdet får beräknas som det **fiktiva omkostnadsbeloppet enligt kapitalvinstreglerna** vid en marknadsvärdesförsäljning av täktmarken det år utvinningen påbörjades. **Spärr: anskaffningsvärdet får inte överstiga 75 % av täktmarkens marknadsvärde** vid utvinningens början.
 
 Exploateringskostnader (det som inte dragits av i löpande drift) får läggas till anskaffningsvärdet, även efter exploateringens början.
 

--- a/.claude/skills/swedish-jordbruk-skogsbruk/references/skogsbeskattning.md
+++ b/.claude/skills/swedish-jordbruk-skogsbruk/references/skogsbeskattning.md
@@ -10,7 +10,7 @@ Riksdagen beslutade 25 februari 2026 om en sammanhängande reform av skogsbeskat
 |---|---|
 | **Källskatt 15 % på skogskontoränta avskaffas** | Hela räntan sätts in på kontot; beskattas vid uttag som NV-intäkt. Se skogskonto-sektionen. |
 | **Naturvårdskonto NYTT** | Nytt uppskovsinstrument vid naturvårdsavtal — avdrag upp till **90 %** av naturvårdsavtalsersättningen. Insättning på särskilt bankkonto. Bokförs **R28 (insättning) / R27 (uttag)** — samma rutor som skogskonto. Första avdraget i deklaration 2027 (inkomstår 2026). |
-| **Ersättningsfond (IL 31 kap) — användningstid förlängd 3 → 10 år** | Stort lyft för lantbrukare med stor försäkringsersättning eller expropriation; mer tid att hitta ersättningstillgång. |
+| **Ny ersättningsfond för naturvårdsmark (10 år)** | Reformen inför en *ny* fondtyp, ersättningsfond för naturvårdsmark, med 10 års användningstid. Övriga ersättningsfonder (inventarier, byggnader/markanläggning, mark, djurlager) behåller sin 3-åriga frist (förlängningsbar till 6 år via dispens). |
 | **Skogsavdrag utvidgat till EES** | Tidigare gällde IL 21 kap endast skogsmark i Sverige. Nu kan svenska skogsägare även göra skogsavdrag för skog inom EES-området under samma villkor. |
 | **Skatteverkets ställningstagande dnr 8-2883764 (2024-06-17)** | Kodifierar tolkningen efter HFD 2023 ref. 59 om rationaliseringsförvärv. Upphäver dnr 131-80453-13/111 (2013). Det gamla får tillämpas på förvärv före 1 oktober 2024. |
 
@@ -142,7 +142,7 @@ Vid omarrondering: utgifter för lantmäteriförrättning som är ett led i yttr
 
 ### Rationaliseringsförvärv (IL 21 kap 10§)
 
-Fysisk person som förvärvar skog som ett led i jord- och skogsbrukets yttre rationalisering får under de **första fem åren** efter förvärvet dra av **100% av avdragsgrundande skogsintäkten** (i stället för 50%).
+Fysisk person som förvärvar skog som ett led i jord- och skogsbrukets yttre rationalisering får under **förvärvsåret och de fem följande kalenderåren** (totalt sex år) dra av **100% av avdragsgrundande skogsintäkten** (i stället för 50%).
 
 #### HFD 2023 ref. 59 — VIDGAD TILLÄMPNING (mål 1087-23, dom 2023-12-28)
 
@@ -154,14 +154,13 @@ Genom HFD 2023 ref. 59 räcker det att tillköpet ger kostnadseffektivare maskin
 
 Skatteverket kodifierade tolkningen efter HFD 2023 ref. 59 i ett nytt ställningstagande som **upphäver dnr 131-80453-13/111** (2013). Nuvarande SKV-position:
 
-- Brukningsenhet definieras enligt **Skogsvårdslagen 12 §**
-- Brukningsenhet ska vara **≥ 400 hektar** efter förvärvet
-- Både ursprungligen ägda och tillköpta delarna måste utgöra **> 10 %** av den nya enheten
-- Helst samma kommun (eller god vägförbindelse)
+- Brukningsenhet definieras enligt **Skogsvårdslagen 12 §** (inte längre en fast hektargräns)
+- Bedömningen görs individuellt: ger tillköpet en kostnadseffektivare brukningsenhet? Den tidigare fasta gränsen "≥ 400 hektar / redan rationell" från 2013-ställningstagandet är **slopad** — den hörde till den upphävda positionen, inte den nuvarande.
+- Tillköpet ska normalt avse samma brukningsenhet och ägas i samma proportion; helst samma kommun eller med god vägförbindelse
 
 Övergångsregel: 2013-positionen får fortfarande tillämpas på **förvärv före 1 oktober 2024**. Förvärv därefter följer den nya tolkningen.
 
-Praktisk konsekvens: tillämpningsområdet för 100 %-regeln är betydligt bredare än äldre beskrivningar anger. Software bör inte automatiskt avvisa rationaliseringskvalifikation pga storlek på ursprungsfastighet — men kontrollera ≥ 400 ha och 10 %-proportionerna mot SKV-vägledningen.
+Praktisk konsekvens: tillämpningsområdet för 100 %-regeln är betydligt bredare än äldre beskrivningar anger. Software bör inte automatiskt avvisa rationaliseringskvalifikation pga storlek på ursprungsfastighet — bedömningen är numera kvalitativ (ger tillköpet en kostnadseffektivare brukningsenhet?), inte en fast hektargräns. Kontrollera mot aktuell SKV-vägledning.
 
 #### Övriga villkor (kvarstår oförändrade)
 
@@ -375,7 +374,7 @@ Egen sammanställning (deklarationsprogram BL SKATT, Visma, m.fl. inkluderar den
    + 0,60 × Leveransvirke_likvid
    + 0,60 × Egenuttag_marknadsvärde
    + 1,00 × Uttag_från_betalningsplan_på_tidigare_avverkningsrätt
-4. Maxavdrag_året = Avdragsgrundande × 0,50            # 1,00 vid rationaliseringsförvärv första 5 åren
+4. Maxavdrag_året = Avdragsgrundande × 0,50            # 1,00 vid rationaliseringsförvärv (förvärvsåret + 5 år)
 5. Faktiskt_avdrag = min(Maxavdrag_året, Avdragsutrymme_återstående, Lägsta_avdrag_15000)
 6. Avdragsutrymme_återstående -= Faktiskt_avdrag
 ```

--- a/.claude/skills/swedish-jordbruk-skogsbruk/references/skogsbeskattning.md
+++ b/.claude/skills/swedish-jordbruk-skogsbruk/references/skogsbeskattning.md
@@ -1,0 +1,352 @@
+# Skogsbeskattning (Forestry Taxation)
+
+Special rules for skogsbruk under **IL 21 kap** (Inkomstskattelagen 1999:1229). Skogsbeskattning has three distinct tools that overlap and interact: skogsavdrag, skogskonto, and (via betalningsplan) periodisering of avverkningsrätt-intäkter.
+
+## Intäkternas karaktär — three categories
+
+The category determines how much of the income is *avdragsgrundande* (forming the base for skogsavdrag) and how much of it can be deposited on skogskonto.
+
+| Intäktstyp | What it is | Skogsavdrag base | Skogskonto max insättning |
+|---|---|---|---|
+| **Avverkningsrätt** (rotpost/avverkningsuppdrag) | Buyer cuts and removes the timber. Seller is paid based on volume + grade. | 100% av likviden | 60% av likviden |
+| **Leveransvirke** | Seller fells and delivers timber to the buyer's mätstation. | 60% av likviden (40% anses vara värdet av arbetet) | 40% av likviden |
+| **Egna uttag av skogsprodukter** | Owner takes virke for own use, sales not in NV | 60% av marknadsvärdet | 40% av marknadsvärdet |
+
+**Rotpost vs avverkningsuppdrag**:
+- *Rotpost*: each tree measured and priced upfront at kontraktsskrivande. Rare today because of buyers' insistence on volume measurement after felling.
+- *Avverkningsuppdrag* (leveransrotköp): paid per prislista on inmätt virke after avverkning, minus a fixed kr/m³sk fee for the buyer's avverkning + terrängtransport.
+
+Both are *avverkningsrätt* in skattemässig mening and qualify for the 100%/60% bases above.
+
+## Skogsplantering
+
+Utgifter for anlagging av ny skog — plantsättning, markberedning, viltstängsel — are **direktavdragsgilla** in NV, despite the long-term value. (IL 21 kap 3§)
+
+This is one of the few cases where future-value-creating utgifter are immediately deductible.
+
+## Betalningsplan (IL 21 kap 2§)
+
+Kontantprincipen — undantag från bokföringsmässiga grunder.
+
+When a skogsägare upplåter en avverkningsrätt (avverkningsuppdrag eller rotpost) **och** the parties agree the payment will be split across multiple kalenderår, only the amounts actually received in a given year need to be taken up as inkomst.
+
+Requirements:
+1. Upplåtelse av avverkningsrätt (does NOT apply to leveransvirke or self-cut virke).
+2. Payment must be split across at least **two kalenderår** (not just two tillfällen — different calendar years).
+3. Frivilligt avsteg från huvudregeln — skogsägaren can choose to ta upp hela likviden direct istället.
+
+Length of plan: typically 5-10 år. Some virkesköpare allow modifications during the avtalstid, others lock the schedule.
+
+### Räntekompensation
+
+Virkesköpare typically pay ränta on innestående medel på betalningsplan. Räntan beskattas som intäkt i NV (not kapital), is moms-fri, and follows the same rate as skogskonto-räntan from competing banks.
+
+### Betalningsplan vid räntefördelning och expansionsfond
+
+CRITICAL anomaly (IL 2 kap 31§): A fordran from betalningsplan is **not obeskattad** in skattemässig mening (the intäkt has not yet been beskattad). Therefore:
+- Räntefördelning kapitalunderlag: **0%** of the betalningsplan-fordran. The fordran is NOT räknad as tillgång.
+- Expansionsfond kapitalunderlag: same — 0%.
+- Skogskonto, in contrast, enters kapitalunderlag at **50%** (the depositions ARE obeskattade since the intäkt was beskattad in samband med avräkning/inmätning).
+
+**Implementation note**: A system that lets the user toggle between betalningsplan and skogskonto must recompute both kapitalunderlag — the choice has multi-year capitalunderlag effects.
+
+### Betalningsplan can not be overlåten
+
+IL 21 kap 2§ + Skatteverkets ställningstagande dnr 131 127228-08/111: A betalningsplan-fordran cannot be transferred to another taxpayer — the fordran is personlig till the original upplåtaren. **Exception**: Dödsbo after the upplåtaren can fortsätta tillämpa the betalningsplan.
+
+### When is the intäkt beskattad?
+
+HFD 2017 ref 58, 2017-10-20 (Mål om tidpunkten för beskattning av inkomst från upplåtelse av rätt att avverka skog): När skogsägaren INTE utnyttjar betalningsplan-möjligheten ska ersättningen från ett avverkningsuppdrag redovisas och beskattas **när virket inmäts** — NOT när avtalet skrivs och NOT när dellikvid betalas i förskott. Skälet är att äganderätten övergår när virket mäts in.
+
+Detta innebär att ett förskott före inmätning ska redovisas som en **skuld** (ej inkomst). Likvid efter inmätning men före betalning är en **kundfordran**.
+
+## Förskott på leveransvirke
+
+Mottager skogsägaren förskott för virke som ännu inte levererats eller mätts in:
+- **Inkomstskatt**: Förskottet är en **skuld**, ej intäkt. Tas upp som intäkt först när virket mäts in (eller köparen lämnar avräkning).
+- **Moms**: Däremot ska moms redovisas på förskottet om den som betalat ut förskottet har specificerat moms på det. Asymmetri: moms redovisas i en period, inkomstskatt i en annan.
+- **Skogsavdrag**: Förskott är **inte** underlag för skogsavdrag (och inte heller skogskonto). Endast när virket mäts in räknas det som avdragsgrundande skogsintäkt.
+
+## Skogsavdrag (IL 21 kap 4-19 §§)
+
+The grundläggande tanke: at sale of a skogsfastighet, an unfair tax effect would arise if the seller has been forced to skatta för all virke they sell, without being able to dra av the inköpspris på den rotstående virke they bought. Skogsavdraget addresses this.
+
+### The two pillars
+
+**Avdragsutrymme** (lifetime cap):
+- Fysisk person + dödsbo: **50% of anskaffningsvärdet** for skog och skogsmark.
+- Juridisk person (AB, HB, ekonomisk förening, stiftelse): **25%** of anskaffningsvärdet.
+
+**Avdragsgrundande skogsintäkt** (per-year base):
+- 100% av intäkter from avverkningsuppdrag (incl. avverkningsrätt, rotpost).
+- 60% av intäkter from leveransvirke + egna uttag.
+
+**Årets skogsavdrag** = max **50% av avdragsgrundande skogsintäkt** (gäller alla fysiska personer).
+
+Combined effect: max year-skogsavdrag = 50% of (100% of avverkningsuppdrag) + 50% of (60% of leveransvirke) = up to 50% of avverkningsuppdrag-likvid OR 30% of leveransvirke-likvid.
+
+### Anskaffningsvärdet — three methods to calculate
+
+**1. Ren skogsfastighet**: anskaffningsvärdet = vad du betalt för hela fastigheten. Simple.
+
+**2. Blandad fastighet (huvudregel — schablonregeln efter taxeringsvärdet)** (IL 21 kap 12§):
+   - anskaffningsvärdet för skogen = (köpeskillingen × skogsbruksvärdet / totala taxeringsvärdet)
+   - Example: Fastighet köpt för 800 000 kr. Taxeringsvärde 550 000 kr varav skogsbruksvärde 110 000 kr. Anskaffningsvärde skog = 110 000 / 550 000 × 800 000 = 160 000 kr.
+
+**3. Jämkningsregeln** (IL 21 kap 13§): Om det är uppenbart att schablonregeln ger missvisande värde, tillåts proportionering efter särskild värdering (intyg from Skogsstyrelsen eller registrerad fastighetsmäklare). Värderingen ska vara i kronor, inte procent — men man bedömer hur stor *andel* av totala värdet som ligger i skog och skogsmark.
+
+Justifiable jämkning:
+- Brist på avverkning sedan taxeringsvärdet fastställdes (skogen har vuxit) → högre skogsvärde
+- Vikande marknad på åkermark eller byggnader
+- Felaktigheter i tidigare fastighetstaxering
+- Stora framtida återväxtåtgärder ogjorda
+
+### Anskaffningsvärde — what counts?
+
+Anskaffningsvärdet excludes:
+- Lagfartskostnader (stämpelskatt 1.5% + expeditionsavgift)
+- Mäklarkostnader
+- Fastighetsbildningsutgifter
+- ...EXCEPT vid rationaliseringsförvärv where lagfartskostnaden FÅR ingå.
+
+Vid omarrondering: utgifter för lantmäteriförrättning som är ett led i yttre rationalisering ska INTE räknas in i anskaffningsvärdet (de är direkt avdragsgilla i NV).
+
+### Arv och gåva
+
+- Vid arv och gåva: mottagaren övertar givarens/arvlåtarens *anskaffningsvärde* (och hur mycket skogsavdrag som redan utnyttjats). No indexuppräkning.
+- Vid delöverlåtelse (gåva of part): mottagarens del = (mottagarens fastighetsdel/hela fastigheten) × givarens anskaffningsvärde. Givarens kvarvarande anskaffningsvärde minskas motsvarande.
+- Om delen är liten — mindre än 20% av skogsvärdet — ingen anskaffningsvärde alls för mottagaren; givarens anskaffningsvärde är oförändrat.
+- Om värdet av all skog och skogsmark i överlåtarens NV är **mindre än 20%** av det överlåtna området, får mottagaren inget anskaffningsvärde alls.
+
+### Arv vs köp — Skatteverkets klassificering
+
+1. Arvinge tillskiftas → arv.
+2. Arvinge löser ut alla andra dödsbodelägare och betalar arvskifteslikvid → arv (även om transaktionen kallas köp).
+3. Arvinge köper fastigheten av dödsbo där hen är delägare, och köpet INTE görs i samband med arvskifte: andelen som motsvarar arvtagarens andel i dödsboet = arv; resten = köp.
+4. Efterlevande make tillskiftas i bodelning, sedan sälja vidare till annan dödsbodelägare: upplägg för skatteflykt → bedöms som arv enligt punkt 3.
+5. Arvinge tillskiftas en fastighet med lågt underlag för skogsavdrag och säljer till make med pris under kapitalvinsttaket: godkänns som rent köp.
+
+### Rationaliseringsförvärv (IL 21 kap 10§)
+
+Fysisk person som förvärvar skog som ett led i jord- och skogsbrukets yttre rationalisering får under de **första fem åren** efter förvärvet dra av **100% av avdragsgrundande skogsintäkten** (i stället för 50%).
+
+Conditions (Skatteverket dnr 131 80453-13/111):
+- Den tidigare ägda fastigheten får inte redan vara en rationell brukningsenhet (gräns: 400 hektar produktiv skogsmark).
+- Det får inte vara för stort avstånd mellan fastigheterna (gräns: vägavstånd högst 3 mil).
+- Den tidigare ägda eller den förvärvade fastigheten ska öka arealen produktiv skogsmark med minst **10%**.
+
+NB: rationaliseringseffekten ökar bara *hastigheten* — det totala avdragsutrymmet (50% av anskaffningsvärdet) gäller fortfarande.
+
+Lagfartskostnader **får** ingå i anskaffningsvärdet vid rationaliseringsförvärv.
+
+### Avdragsbelopp — lägsta belopp
+
+- **Egen ägare** (hel fastighet): lägsta avdrag/år **15 000 kr** (IL 21 kap 18§).
+- **Delägare** (samägt): lägsta avdrag **3 000 kr** per delägare, men det beräknade avdraget för hela den gemensamt bedrivna verksamheten måste vara minst **15 000 kr**. En delägare får utnyttja skogsavdrag även om de andra avstår.
+- Inget tak för enskilt år utöver 50%-regeln.
+
+### Skogsavdrag minskar inte vid uttag från skogskonto
+
+Uttag från skogskonto räknas inte som avdragsgrundande skogsintäkt (det är ju samma pengar som tidigare gett upphov till skogsavdrag). Insättning på skogskonto minskar INTE skogsavdraget i samma år; båda räknas på samma underlag.
+
+### Avveckling av skogsmark — inget kvarvarande utrymme
+
+När hela skogsmarken är avyttrad får inget skogsavdrag göras, även om avverkning sker på grund av förbehållen avverkningsrätt EFTER försäljning. Inget avdragsutrymme kvarstår.
+
+## Framtida återväxtåtgärder
+
+För den som **gör ett vanligt årsbokslut** (inte förenklat): avdragsgill avsättning i räkenskaperna för beräknade utgifter för kommande återväxtåtgärder (markberedning, plantering, skyddsdikning, slyröjning). När utgifterna senare uppkommer, är de redan avdragna och får inte dras av igen.
+
+**Förenklat årsbokslut → INTE rätt till avsättning** för framtida återväxtåtgärder. Detta är den största nackdelen med förenklat årsbokslut för skogsägare. Alternativen för att uppnå samma skattekredit:
+- Avsättning till **periodiseringsfond** (6 års skattekredit, max 30% av vinsten)
+- Använda **betalningsplan** så att pengar står inne hos köparen — pengarna kan tas ut när återväxtåtgärderna utförs så att intäkter och kostnader möter varandra.
+
+**Inte i samband med betalningsplan**: Om man redan har pengar innestående på betalningsplan, är detta tillräcklig skattekredit — får då inte dessutom göra avdrag för framtida återväxtåtgärder (RÅ 1997 ref 52).
+
+## Energiskog
+
+Försäljning av bränsle från energiskog (pil, sälg mm) på åkermark räknas som försäljning av gröda, inte skogsinkomst. Det innebär:
+- INTE skogskontogrundande
+- INTE underlag för skogsavdrag
+- Beskattas som vanlig inkomst i NV.
+
+## Skogskonto (IL 21 kap 21-37 §§)
+
+Skattekredit på upp till 10 år. Pengar sätts in på ett särskilt bankkonto, avdrag görs i NE-blanketten, källskatt 15% dras av räntan vid utbetalningen, uttag tas upp som intäkt i NV.
+
+### Skogskontots syfte
+
+1. **Skatteutjämning mellan år** — kapa toppinkomster för att jämna ut den progressiva statliga skatten.
+2. **Skattekredit** upp till 10 år (även utan progressivt utfall är skattekrediten värd ca 30%-marginalen × räntan).
+3. **Skatteskyddat sparande** — 15% källskatt på räntan i stället för 30% på vanlig bankränta.
+
+### Vem får sätta in?
+
+Endast **människor och dödsbon** (IL 21 kap 21§). Aktiebolag, ekonomiska föreningar, handelsbolag → INTE. Anledningen är att skogskontot är konstruerat för att kapa progressivt utfall, vilket inte finns för juridiska personer.
+
+### Lägsta insättningsbelopp
+
+**5 000 kr** per delägare per beskattningsår. Om gemensamt bedriven verksamhet — beloppsgränsen 5 000 kr gäller var och en av delägarna (IL 21 kap 31§).
+
+### Maxinsättning per år (IL 21 kap 25, 29 och 31 §§)
+
+Summan av:
+- **60%** av inkomster från avverkningsuppdrag eller avverkningsrätt
+- **40%** av inkomster från virkesförsäljning (oavsett om du själv eller annan gör avverkningen)
+- **40%** av värdet av egna uttag av skogsprodukter
+
+Plus följande särskilda intäkter får ingå:
+- Försäkringsersättning för skog eller virke
+- Delutbetalning för avverkningsrätt enligt betalningsplan
+- Utdelning från samfällighet som tas upp i skogsbruket
+
+Uttag från skogskonto räknas **inte** som skogskontogrundande intäkt. Förskott för ej levererat eller inmätt virke får **inte** räknas med.
+
+### Skogsskador — förhöjd insättning (skogsskadekonto)
+
+Vid skogsskador (stormfällning, brand, insektsangrepp, kemiska skador eller liknande) som tvingat skogsägaren att avverka tidigare än önskat: förhöjd insättning är möjlig.
+
+- **80%** av inkomster från avverkningsuppdrag/avverkningsrätt
+- **50%** av virkesförsäljning, oavsett om du eller någon annan gör avverkningen
+
+Villkor:
+- Skadan ska ha gjort att mer än 1/3 av skogen bör avverkas tidigare än tänkt.
+- Minst 75% av skogsintäkterna under året (inkl. försäkringsersättning) ska vara på grund av stormfällning, brand eller liknande.
+
+Andra skador som ger förhöjd insättning: torka, svampangrepp, översvämning, skador genom industriutsläpp.
+
+**Intyg krävs** från oberoende sakkunnig (t.ex. Skogsstyrelsen-tjänsteman, virkesköpare). Blankett SKV2464.
+
+### Skogsskadekonto — skillnader mot vanligt skogskonto
+
+- Lägsta insättning per år: **50 000 kr** (mot 5 000 kr för vanligt skogskonto).
+- Pengar får stå kvar i **20 år** (mot 10 år för skogskonto).
+- IL 21 kap 23, 24 och 31 §§.
+
+### Bara ett konto per år och bank
+
+Per beskattningsår, ett konto per skogsägare per bank. Skulle insättning ske på flera konton räknas bara den första insättningen som godkänd. Resten flyttas till vanligt bankkonto (RÅ 1979 1:52 — varje delägare måste ha eget konto för sin egen del).
+
+Däremot: olika beskattningsår kan ha **olika** skogskonton (max 10 samtidigt eftersom max 10 år).
+
+### Skogskontoräntan — specialbeskattning (källskatt)
+
+**15% källskatt** på räntan. Banken drar av och betalar in till Skatteverket direkt — räntan syns INTE i deklarationen och får inte räknas in i preliminärskatten.
+
+Effektiv skatt på skogskontot är dock högre när uttag sker:
+- Vid uttag: hela beloppet (inklusive räntan, sedan banken redan dragit 15%) beskattas som inkomst av NV, alltså 0-60% beroende på age, marginalskatt, aktiv/passiv.
+- Exempel: marginalskatt + egenavgifter = 50%. Insatt 100 000 kr, ränta 1% = 1 000 kr. Källskatt 15% × 1 000 = 150 kr. Resterande 850 kr beskattas med 50% = 425 kr vid uttag. Total skatt på räntan: 575 kr = 57.5%.
+
+Räntan vid skogskonto är dock **delvis skatteskyddat sparande** jämfört med 30% kapitalskatt på en vanlig bankränta (om man inte skulle behöva räntan i NV).
+
+### Uttagsregler
+
+- Tidigast **4 månader** efter insättningen får uttag göras.
+- Minsta uttag **1 000 kr** (såvida kontot inte avslutas).
+- **10 år** från början av det år då senaste insättning gjordes — då måste banken avsluta kontot och betala ut.
+- Exempel: insättning 2020 (deklaration 2021) → måste tas ut senast 2030 (deklaration 2031).
+
+### Skogskonto vid fastighetsöverlåtelse
+
+- Vid försäljning: skogskontot finns kvar oberoende av att fastigheten sålts. Uttag deklareras som passiv NV (när annan aktiv NV saknas) — vilket kan ge **24.26% löneskatt** istället för 10.21% egenavgifter för pensionärer (oförmånligt).
+- Vid arv/gåva av hela lantbruksenheten: mottagaren får **överta** skogskontot. Insättning förs vidare med samma 10-årsfrist. Mottagaren tar sedan upp uttag till beskattning. Blankett N7 anmäler övertagandet.
+- Skogskontot kan **inte** delas mellan flera mottagare vid arv eller gåva — det måste följa lantbruksenheten i sin helhet.
+- Vid delöverlåtelse (arealförvärv): övertaget belopp = (kontobehållning × mottagarens ägarandel × taxeringsvärde för övertagen skogsmark / taxeringsvärde för all skogsmark).
+
+### Pantsättning — INTE tillåten
+
+Skogskontot får inte pantsättas eller på annat sätt lämnas som säkerhet. Den som upptäcker pantsättning ska genast beskatta hela kontobehållningen som uttag (IL 21 kap 36-37 §§).
+
+Spärrning från Skogsstyrelsen för skogsvårdsåtgärder räknas inte som pantsättning.
+
+### Felaktig insättning
+
+Om Skatteverket nekar avdrag (för att underskott uppstår eller belopp överstiger 40/60% av intäkten):
+- Skatteverket meddelar banken.
+- Banken flyttar pengarna till vanligt bankkonto, även räntan (som då räknas som vanlig ränta i kapital).
+- Ingen "fångenskap" på kontot om Skatteverket inte godkänner insättningen.
+
+### Skogskonto vid räntefördelning och expansionsfond
+
+Skogskontobehållningen får räknas in i kapitalunderlaget för räntefördelning och expansionsfond — men bara till **50%** av behållningen (medan vanliga bankkonton räknas till 100%).
+
+**Implikation**: Att lägga upp skogspengar på ett likvidkonto i lantbruket är effektivare för räntefördelning än att låsa dem på skogskonto — men då förlorar man källskatten 15% och 10-årig skattekredit. Trade-off.
+
+## Lager av skogsprodukter
+
+Skogsprodukter värderas som andra lagervaror (IL 17 kap). Egenavverkat virke vid bilväg, som ännu inte mätts in för köparens räkning, ska tas upp som lager vid årets slut.
+
+Är virket inmätt vid årsskiftet ingår det INTE i lagret — det är då i *köparens* lager. Likviden tas upp som en **kundfordran** (intäkt).
+
+### BAS-konton lager skogsprodukter
+
+| Konto | Användning |
+|---|---|
+| 1460 / 1465 | Lager skogsprodukter |
+| 1469 | Inkuransavdrag 3% |
+
+## N8-blanketten — Skogs- och substansminskningsavdrag
+
+N8 är en underbilaga till NE (för enskilda näringsidkare), INK2 (AB), INK3 (ekonomiska föreningar) eller INK4 (HB). N8 är **inte** själva beräkningen — Skatteverket räknar inte ut beloppen själva, utan N8 är ett sätt att hålla reda på vilka avdrag som gjorts och på vilka fastigheter.
+
+### N8 A. Skogsavdrag
+
+- **A1. Begärt skogsavdrag för beskattningsåret**: belopp förs till NE R25 (eller motsvarande på INK2/INK3/INK4).
+- **A2. Återfört skogsavdrag**: om fastighet sålts under året och skogsavdrag återförs vid kapitalvinstberäkningen. Förs till NE R26 (intäkt).
+- **A3. Ökat/minskat avdragsutrymme**: vid förvärv ökas, vid avyttring minskas.
+
+### N8 B. Substansminskningsavdrag
+
+Samma struktur (B1, B2, B3) för naturtillgångar (grus, torv, bergtäkter).
+
+### BSKA — Beräkningsbilaga för skogsavdrag
+
+Egen sammanställning (deklarationsprogram BL SKATT, Visma, m.fl. inkluderar denna). Inte ett officiellt Skatteverketsformulär, men rekommenderat första gången skogsavdrag yrkas. BSKA-bilagan visar:
+- Hur anskaffningsvärdet räknats ut (schablonregeln eller jämkningsregeln)
+- Hur avdragsutrymmet räknats ut (50% × anskaffningsvärde, minus tidigare skogsavdrag)
+- Årets avdragsgrundande skogsintäkter (rotpostförsäljning + 60% × leveransvirke)
+- Yrkat skogsavdrag (max 50% av avdragsgrundande intäkten, eller 100% vid rationaliseringsförvärv)
+- Kvarvarande avdragsutrymme
+
+### Worked example (BSKA — Enar Gran)
+
+Enar köpte sin skogsfastighet för 1 600 000 kr. Taxeringsvärde 1 100 000 kr, varav skogsbruksvärde 220 000 kr.
+
+Anskaffningsvärde för skog = 1 600 000 × 220 000 / 1 100 000 = **320 000 kr**.
+
+Avdragsutrymme = 320 000 × 50% = **160 000 kr**.
+
+Under året:
+- Avverkningsuppdrag 48 000 kr
+- Uttag från betalningsplan (tidigare avverkningsuppdrag) 42 000 kr
+- Total avdragsgrundande skogsintäkt = 48 000 + 42 000 = 90 000 kr
+
+Maxavdrag = 50% × 90 000 = **45 000 kr**.
+
+Yrkat: 45 000 kr på N8 A1 → NE R25.
+
+Kvarvarande avdragsutrymme = 160 000 − 45 000 = **115 000 kr**.
+
+## Rättsfall & ställningstaganden
+
+| Källa | Innehåll |
+|---|---|
+| HFD 2017 ref 58 (mål 20 oktober 2017) | Tidpunkten för beskattning av inkomst från upplåtelse av rätt att avverka skog: vid inmätning, inte vid avtalsskrivning |
+| RÅ 1979 1:52 | Varje delägare måste ha eget skogskonto — gemensamt konto för flera personer accepteras inte |
+| RÅ 1988 ref 72 | Helt avdrag för insättning trots hälftenägare (om kontohavaren brukade hela fastigheten) |
+| RÅ 1997 ref 52 | Avdrag för framtida återväxtåtgärder medgavs inte när skogsägaren även hade pengar innestående på betalningsplan |
+| Skatteverkets ställningstagande dnr 131 551127-08/111 | Förenklat årsbokslut och betalningsplan på skog |
+| Skatteverkets ställningstagande dnr 131 127228-08/111 | Överlåtelse av betalningsplan |
+| Skatteverkets ställningstagande dnr 131 265526-07/111, 2007-06-13 | Återföring av skogsavdrag |
+| Skatteverkets ställningstagande dnr 131 80453-13/111 | Definition av rationaliseringsförvärv |
+
+## Quick-reference: per-intäktstyp summary
+
+| Intäktstyp | % i skogsavdrag-bas | % på skogskonto | Skogsskadekonto-% | Moms |
+|---|---|---|---|---|
+| Avverkningsuppdrag (rotpost/avverkningsrätt) | 100% | 60% | 80% | 25% (skog är råvara) |
+| Leveransvirke | 60% | 40% | 50% | 25% |
+| Egna uttag skogsprodukter | 60% | 40% | (n/a) | 25% (uttagsmoms) |
+| Energiskog från åker (pil, sälg) | 0% (inte skogsinkomst) | 0% | 0% | 12% om livsmedel, annars 25% |
+| Försäkringsersättning skog | 0% (i regel) | räknas in i underlaget | 50%/80% | momsfri |
+| Förskott innan inmätning | 0% (är skuld) | 0% (förskott räknas inte) | 0% | 25% (moms ändå) |

--- a/.claude/skills/swedish-jordbruk-skogsbruk/references/skogsbeskattning.md
+++ b/.claude/skills/swedish-jordbruk-skogsbruk/references/skogsbeskattning.md
@@ -2,6 +2,20 @@
 
 Special rules for skogsbruk under **IL 21 kap** (Inkomstskattelagen 1999:1229). Skogsbeskattning has three distinct tools that overlap and interact: skogsavdrag, skogskonto, and (via betalningsplan) periodisering of avverkningsrätt-intäkter.
 
+## Skogsskattereformen 2026 — viktig översikt
+
+Riksdagen beslutade 25 februari 2026 om en sammanhängande reform av skogsbeskattningen (**prop. 2025/26:69, SkU18**), ikraft **1 april 2026**. Huvudpunkterna:
+
+| Förändring | Detalj |
+|---|---|
+| **Källskatt 15 % på skogskontoränta avskaffas** | Hela räntan sätts in på kontot; beskattas vid uttag som NV-intäkt. Se skogskonto-sektionen. |
+| **Naturvårdskonto NYTT** | Nytt uppskovsinstrument vid naturvårdsavtal — avdrag upp till **90 %** av naturvårdsavtalsersättningen. Insättning på särskilt bankkonto. Bokförs **R28 (insättning) / R27 (uttag)** — samma rutor som skogskonto. Första avdraget i deklaration 2027 (inkomstår 2026). |
+| **Ersättningsfond (IL 31 kap) — användningstid förlängd 3 → 10 år** | Stort lyft för lantbrukare med stor försäkringsersättning eller expropriation; mer tid att hitta ersättningstillgång. |
+| **Skogsavdrag utvidgat till EES** | Tidigare gällde IL 21 kap endast skogsmark i Sverige. Nu kan svenska skogsägare även göra skogsavdrag för skog inom EES-området under samma villkor. |
+| **Skatteverkets ställningstagande dnr 8-2883764 (2024-06-17)** | Kodifierar tolkningen efter HFD 2023 ref. 59 om rationaliseringsförvärv. Upphäver dnr 131-80453-13/111 (2013). Det gamla får tillämpas på förvärv före 1 oktober 2024. |
+
+Källor: Riksdagsbeslut 2026-02-25, prop. 2025/26:69, SkU18.
+
 ## Intäkternas karaktär — three categories
 
 The category determines how much of the income is *avdragsgrundande* (forming the base for skogsavdrag) and how much of it can be deposited on skogskonto.
@@ -130,10 +144,29 @@ Vid omarrondering: utgifter för lantmäteriförrättning som är ett led i yttr
 
 Fysisk person som förvärvar skog som ett led i jord- och skogsbrukets yttre rationalisering får under de **första fem åren** efter förvärvet dra av **100% av avdragsgrundande skogsintäkten** (i stället för 50%).
 
-Conditions (Skatteverket dnr 131 80453-13/111):
-- Den tidigare ägda fastigheten får inte redan vara en rationell brukningsenhet (gräns: 400 hektar produktiv skogsmark).
+#### HFD 2023 ref. 59 — VIDGAD TILLÄMPNING (mål 1087-23, dom 2023-12-28)
+
+Skatteverkets tidigare ställningstagande **dnr 131 80453-13/111** (2013) krävde att den ursprungliga brukningsenheten *inte* redan var rationell, vilket sattes som riktmärke vid t.ex. 400 ha produktiv skogsmark. **Det rättsläget gäller inte längre.**
+
+Genom HFD 2023 ref. 59 räcker det att tillköpet ger kostnadseffektivare maskin- och arbetsanvändning genom större areal — **oavsett om den ursprungliga brukningsenheten redan var stor**. Storskaliga sammanslagningar räknas också som rationalisering.
+
+#### Skatteverkets nya ställningstagande dnr 8-2883764 (2024-06-17)
+
+Skatteverket kodifierade tolkningen efter HFD 2023 ref. 59 i ett nytt ställningstagande som **upphäver dnr 131-80453-13/111** (2013). Nuvarande SKV-position:
+
+- Brukningsenhet definieras enligt **Skogsvårdslagen 12 §**
+- Brukningsenhet ska vara **≥ 400 hektar** efter förvärvet
+- Både ursprungligen ägda och tillköpta delarna måste utgöra **> 10 %** av den nya enheten
+- Helst samma kommun (eller god vägförbindelse)
+
+Övergångsregel: 2013-positionen får fortfarande tillämpas på **förvärv före 1 oktober 2024**. Förvärv därefter följer den nya tolkningen.
+
+Praktisk konsekvens: tillämpningsområdet för 100 %-regeln är betydligt bredare än äldre beskrivningar anger. Software bör inte automatiskt avvisa rationaliseringskvalifikation pga storlek på ursprungsfastighet — men kontrollera ≥ 400 ha och 10 %-proportionerna mot SKV-vägledningen.
+
+#### Övriga villkor (kvarstår oförändrade)
+
 - Det får inte vara för stort avstånd mellan fastigheterna (gräns: vägavstånd högst 3 mil).
-- Den tidigare ägda eller den förvärvade fastigheten ska öka arealen produktiv skogsmark med minst **10%**.
+- Den tidigare ägda eller den förvärvade fastigheten ska öka arealen produktiv skogsmark.
 
 NB: rationaliseringseffekten ökar bara *hastigheten* — det totala avdragsutrymmet (50% av anskaffningsvärdet) gäller fortfarande.
 
@@ -178,7 +211,7 @@ Skattekredit på upp till 10 år. Pengar sätts in på ett särskilt bankkonto, 
 
 1. **Skatteutjämning mellan år** — kapa toppinkomster för att jämna ut den progressiva statliga skatten.
 2. **Skattekredit** upp till 10 år (även utan progressivt utfall är skattekrediten värd ca 30%-marginalen × räntan).
-3. **Skatteskyddat sparande** — 15% källskatt på räntan i stället för 30% på vanlig bankränta.
+3. **Skatteskyddat sparande** — 15 % källskatt på räntan i stället för 30 % på vanlig bankränta. *Obs:* Denna källskatt **slopas 1 april 2026** (riksdagsbeslut hösten 2025); efter dess sätts hela räntan in på kontot och beskattas som NV vid uttag.
 
 ### Vem får sätta in?
 
@@ -229,15 +262,18 @@ Per beskattningsår, ett konto per skogsägare per bank. Skulle insättning ske 
 
 Däremot: olika beskattningsår kan ha **olika** skogskonton (max 10 samtidigt eftersom max 10 år).
 
-### Skogskontoräntan — specialbeskattning (källskatt)
+### Skogskontoräntan — specialbeskattning (källskatt) — SLOPAS 2026-04-01
 
-**15% källskatt** på räntan. Banken drar av och betalar in till Skatteverket direkt — räntan syns INTE i deklarationen och får inte räknas in i preliminärskatten.
+**Före 2026-04-01**: **15 % källskatt** på räntan. Banken drar av och betalar in till Skatteverket direkt — räntan syns INTE i deklarationen och får inte räknas in i preliminärskatten.
 
-Effektiv skatt på skogskontot är dock högre när uttag sker:
-- Vid uttag: hela beloppet (inklusive räntan, sedan banken redan dragit 15%) beskattas som inkomst av NV, alltså 0-60% beroende på age, marginalskatt, aktiv/passiv.
-- Exempel: marginalskatt + egenavgifter = 50%. Insatt 100 000 kr, ränta 1% = 1 000 kr. Källskatt 15% × 1 000 = 150 kr. Resterande 850 kr beskattas med 50% = 425 kr vid uttag. Total skatt på räntan: 575 kr = 57.5%.
+**Fr.o.m. 1 april 2026**: **Källskatten 15 % på skogskontoränta avskaffas.** Hela räntan sätts i stället in på kontot och beskattas som NV-inkomst när uttag görs (riksdagsbeslut hösten 2025 som del av paketet att förenkla räntebeskattning; ingår i Skogsskattereformen 2026 — se översikten överst i denna fil).
 
-Räntan vid skogskonto är dock **delvis skatteskyddat sparande** jämfört med 30% kapitalskatt på en vanlig bankränta (om man inte skulle behöva räntan i NV).
+Effektiv skatt på skogskontot (för pre-2026-04-01-räntor) är dock högre när uttag sker:
+- Vid uttag: hela beloppet (inklusive räntan, sedan banken redan dragit 15 %) beskattas som inkomst av NV, alltså 0–60 % beroende på ålder, marginalskatt, aktiv/passiv.
+- Exempel pre-reform: marginalskatt + egenavgifter = 50 %. Insatt 100 000 kr, ränta 1 % = 1 000 kr. Källskatt 15 % × 1 000 = 150 kr. Resterande 850 kr beskattas med 50 % = 425 kr vid uttag. Total skatt på räntan: 575 kr = 57,5 %.
+- Post-reform-exempel (uttag fr.o.m. 2026-04-01): samma ränta 1 000 kr, ingen källskatt — hela 1 000 kr beskattas vid uttag med 50 % = 500 kr.
+
+Räntan vid skogskonto är dock **delvis skatteskyddat sparande** (pre-reform) jämfört med 30 % kapitalskatt på en vanlig bankränta. Efter 2026-04-01 är det vanlig NV-beskattning utan källskattssteget — fortfarande lägre marginalskatt än vanlig kapital om uttag sker under brytpunkten.
 
 ### Uttagsregler
 
@@ -248,7 +284,7 @@ Räntan vid skogskonto är dock **delvis skatteskyddat sparande** jämfört med 
 
 ### Skogskonto vid fastighetsöverlåtelse
 
-- Vid försäljning: skogskontot finns kvar oberoende av att fastigheten sålts. Uttag deklareras som passiv NV (när annan aktiv NV saknas) — vilket kan ge **24.26% löneskatt** istället för 10.21% egenavgifter för pensionärer (oförmånligt).
+- Vid försäljning: skogskontot finns kvar oberoende av att fastigheten sålts. Uttag deklareras som passiv NV (när annan aktiv NV saknas) — vilket ger **24,26 % särskild löneskatt** (SLF, lag 1990:659 om särskild löneskatt på vissa förvärvsinkomster) i stället för 10,21 % egenavgifter för pensionärer (oförmånligt).
 - Vid arv/gåva av hela lantbruksenheten: mottagaren får **överta** skogskontot. Insättning förs vidare med samma 10-årsfrist. Mottagaren tar sedan upp uttag till beskattning. Blankett N7 anmäler övertagandet.
 - Skogskontot kan **inte** delas mellan flera mottagare vid arv eller gåva — det måste följa lantbruksenheten i sin helhet.
 - Vid delöverlåtelse (arealförvärv): övertaget belopp = (kontobehållning × mottagarens ägarandel × taxeringsvärde för övertagen skogsmark / taxeringsvärde för all skogsmark).
@@ -271,6 +307,27 @@ Om Skatteverket nekar avdrag (för att underskott uppstår eller belopp översti
 Skogskontobehållningen får räknas in i kapitalunderlaget för räntefördelning och expansionsfond — men bara till **50%** av behållningen (medan vanliga bankkonton räknas till 100%).
 
 **Implikation**: Att lägga upp skogspengar på ett likvidkonto i lantbruket är effektivare för räntefördelning än att låsa dem på skogskonto — men då förlorar man källskatten 15% och 10-årig skattekredit. Trade-off.
+
+## Naturvårdskonto (NYTT 2026)
+
+Ett nytt uppskovsinstrument införs **1 april 2026** genom **prop. 2025/26:69 (SkU18)**. Naturvårdskontot fungerar likt skogskontot men är specifikt avsett för **engångsersättningar enligt naturvårdsavtal** (frivilliga eller framtvingade naturskydd, biotopskydd, områdesskydd m.m.).
+
+### Huvudregler
+
+- **Avdragsbelopp**: upp till **90 %** av naturvårdsavtalsersättningen får sättas in på naturvårdskonto och dras av som kostnad i NV. (Att jämföra med skogskontots 60 % på avverkningsrätt / 40 % på leveransvirke.)
+- **Insättning på särskilt bankkonto** (naturvårdskonto), enligt liknande regler som skogskonto.
+- **Bokföring i NE-bilaga**: **R28 (insättning)** = samma ruta som skogskonto-insättning; **R27 (uttag)** = samma ruta som skogskonto-uttag. Naturvårdskonto och skogskonto delar alltså samma NE-rutor — kontot identifieras av bankens uppgifter.
+- **Källskatt**: ingen 15 %-källskatt (precis som skogskontot efter 2026-04-01-reformen, dvs samtidigt slopande).
+- **Användningstid**: liknande villkor som skogskonto — kontrollera mot Skatteverkets vägledning för slutgiltiga regler när de publiceras.
+
+### Första avdraget
+
+Naturvårdskontot är användbart fr.o.m. inkomstår 2026 — **första avdraget görs i deklaration 2027**.
+
+### Cross-references
+
+- För räntefördelnings kapitalunderlag — sannolikt samma 50 %-regel som skogskonto (latent skatt), men kontrollera när vägledning publiceras.
+- För N8-blanketten — preliminärt: ingen separat sektion, men kan komma att uppdateras.
 
 ## Lager av skogsprodukter
 
@@ -308,20 +365,22 @@ Egen sammanställning (deklarationsprogram BL SKATT, Visma, m.fl. inkluderar den
 - Yrkat skogsavdrag (max 50% av avdragsgrundande intäkten, eller 100% vid rationaliseringsförvärv)
 - Kvarvarande avdragsutrymme
 
-### Worked example (BSKA — Enar Gran)
+### BSKA-beräkning — strukturell
 
-Enar köpte sin skogsfastighet för 1 600 000 kr. Taxeringsvärde 1 100 000 kr, varav skogsbruksvärde 220 000 kr.
+```
+1. Anskaffningsvärde_skog = Köpeskilling × (Taxeringsvärde_skog / Taxeringsvärde_totalt)
+2. Avdragsutrymme = Anskaffningsvärde_skog × 0,50      # 0,25 för juridisk person
+3. Avdragsgrundande_skogsintäkt =
+     1,00 × Avverkningsuppdrag_likvid
+   + 0,60 × Leveransvirke_likvid
+   + 0,60 × Egenuttag_marknadsvärde
+   + 1,00 × Uttag_från_betalningsplan_på_tidigare_avverkningsrätt
+4. Maxavdrag_året = Avdragsgrundande × 0,50            # 1,00 vid rationaliseringsförvärv första 5 åren
+5. Faktiskt_avdrag = min(Maxavdrag_året, Avdragsutrymme_återstående, Lägsta_avdrag_15000)
+6. Avdragsutrymme_återstående -= Faktiskt_avdrag
+```
 
-Anskaffningsvärde för skog = 1 600 000 × 220 000 / 1 100 000 = **320 000 kr**.
-
-Avdragsutrymme = 320 000 × 50% = **160 000 kr**.
-
-Under året:
-- Avverkningsuppdrag 48 000 kr
-- Uttag från betalningsplan (tidigare avverkningsuppdrag) 42 000 kr
-- Total avdragsgrundande skogsintäkt = 48 000 + 42 000 = 90 000 kr
-
-Maxavdrag = 50% × 90 000 = **45 000 kr**.
+Räkneexempel (illustrativt): köp 2 400 000 kr av blandad lantbruksenhet, taxeringsvärde 1 500 000 kr varav skogsbruksvärde 450 000 kr → anskaffningsvärde_skog = 720 000 kr; avdragsutrymme = 360 000 kr. Avverkningsuppdrag 80 000 kr + leveransvirke 50 000 kr → 80 000 + 30 000 = 110 000 kr avdragsgrundande × 50 % = **55 000 kr maxavdrag**.
 
 Yrkat: 45 000 kr på N8 A1 → NE R25.
 

--- a/.claude/skills/swedish-jordbruk-skogsbruk/references/skogsbeskattning.md
+++ b/.claude/skills/swedish-jordbruk-skogsbruk/references/skogsbeskattning.md
@@ -261,6 +261,12 @@ Per beskattningsår, ett konto per skogsägare per bank. Skulle insättning ske 
 
 Däremot: olika beskattningsår kan ha **olika** skogskonton (max 10 samtidigt eftersom max 10 år).
 
+### Insättningsgaranti — vid stora likvider
+
+Skogskonto och skogsskadekonto omfattas av den statliga insättningsgarantin: **1 150 000 kr per person och institut** (höjt från 1 050 000 kr fr.o.m. 2026-01-01; Riksgälden räknar om beloppet mot euro vart femte år). Belopp däröver är oförsäkrade om banken fallerar.
+
+Eftersom man bara får ha **ett skogskonto per bank och beskattningsår** måste en stor avverkningslikvid spridas på skogskonton i **olika banker** för att varje konto ska rymmas inom garantin. (Det tillfälliga tilläggsskyddet upp till 5 mkr gäller vissa livshändelser, t.ex. försäljning av privatbostad — inte avverkningslikvider.)
+
 ### Skogskontoräntan — specialbeskattning (källskatt) — SLOPAS 2026-04-01
 
 **Före 2026-04-01**: **15 % källskatt** på räntan. Banken drar av och betalar in till Skatteverket direkt — räntan syns INTE i deklarationen och får inte räknas in i preliminärskatten.


### PR DESCRIPTION
## Summary

A new skill, `swedish-jordbruk-skogsbruk`, covering Swedish agriculture and forestry tax for enskild firma with lantbruksenhet. It's written for an LLM to consume — decision tables, pseudocode, BAS-konto mappings — not for a human to read end-to-end.

The branch is 1 SKILL.md, 5 reference files, and one fix commit that aligns everything with 2025-2026 law.

## What's covered

2025-2026 reforms:
- Skogsskattereformen 2026 (prop. 2025/26:69, SkU18): naturvårdskonto, källskatt 15 % slopas, ersättningsfond 3 → 10 år, EES-skogsavdrag
- Livsmedelsmoms 12 % → 6 % tillfälligt 2026-04-01 till 2027-12-31 (prop. 2025/26:55)
- SKVFS 2025:27 (jordbruksdjur), SKVFS 2025:28 (renskötsel), SKV A 2025:8 (nettoförsäljningsvärden)
- Grönt avdrag 20 % → 15 % från 2025-07-01, två-elabonnemang-krav för lantbruk, 5 %-schablon upphörd 2024-03-22, 60-öres mikroproduktions-skattereduktion slopas 2026-01-01

Citations:
- IL (1999:1229), ML (2023:200), BFNAR 2025:1
- HFD 2023 ref. 59 + SKV dnr 8-2883764 (2024-06-17) for rationaliseringsförvärv skogsavdrag
- HFD 2019 mål 6174-6177-18 for solceller momslyft
- Skatteverket dok 394014 (solceller, replaces three older ställningstaganden)

Practical mappings: BAS-kontoplan för lantbruk, NE-bilaga rutor R29-R37 mot SKV 2161, N7/N8.

## Files

```
.claude/skills/swedish-jordbruk-skogsbruk/
  SKILL.md
  references/
    skogsbeskattning.md
    naturtillgangar-och-upplatelser.md
    lantbruksfastighet.md
    bokforing-och-blanketter.md
    lantbruks-moms.md
```

Nothing else is touched.

## Where I'd value another pair of eyes

Since this is reference material for an LLM, what matters is whether the facts are right. The spots I'm least confident about:

1. The numbers — SKVFS 2025:27 djurschablon, SKV A 2025:8 B-värden, 2025/2026 PBB/IBB, skogsavdragskvoter. Easy to mistype.
2. The dates. Skogsskattereformen och livsmedelsmoms-perioden — har jag hamnat rätt på ikraftträdande?
3. NE-rutor R29-R37 mot nuvarande SKV 2161 (inte den gamla layouten före 2018).
4. Two-elabonnemang-kravet för solceller på blandad lantbruksenhet. Jag har byggt det utifrån Skatteverkets nuvarande vägledning, men regeln ligger spridd över flera sidor — bra om någon dubbelkollar.
5. "Bestämd och beställd vara" för förskott på skogsleverans. Jag har använt Skatteverkets dubbla terminologi från ML 2023:200, inte den enklare formen som finns i äldre litteratur.

## Test plan

- [ ] Spot-check siffervärden mot aktuella Skatteverket-föreskrifter
- [ ] Verifiera IL/ML-paragrafer
- [ ] Kör ett verkligt jordbruksbokföringsscenario genom en LLM som har skillen laddad
- [ ] Manuell scan efter verbatim-citat från upphovsrättsskyddat material är gjord — välkomnar en till