### PR TITLE
feat: add swedish-ef-skatteplanering skill (RF-reformen 2025 + reforms through 2026)

### DIFF
--- a/.claude/skills/swedish-ef-skatteplanering/SKILL.md
+++ b/.claude/skills/swedish-ef-skatteplanering/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: swedish-ef-skatteplanering
 description: >
-  Swedish tax planning for enskild firma (sole proprietorship). Covers aktiv vs passiv näringsverksamhet (egenavgifter 28,97% vs SLP 24,26%), räntefördelning (IL 33 kap, positiv SLR+6, negativ SLR+1, kapitalunderlag, sparat fördelningsbelopp), periodiseringsfond EF (30%, no schablonintäkt), expansionsfond (IL 34 kap, 20,6%, 128,21% tak), ersättningsfond (IL 31 kap), kvittning underskott (IL 62:3, 100k cap), inkomstuppdelning familj (IL 60 kap, medhjälpande make), ackumulerad inkomst (IL 66 kap), egenavgifter/SGI/PGI, pensionssparavdrag, EF-vs-AB breakeven. Trigger on enskild firma skatteplanering, näringsidkare, räntefördelning, expansionsfond, ersättningsfond, aktiv/passiv näringsverksamhet, kvittning underskott näring, inkomstuppdelning familj, ackumulerad inkomst, EF vs AB, NE-bilaga, sparat fördelningsbelopp, kapitalunderlag, expansionsskatt, medhjälpande make. For AB use swedish-tax-planning. Always use over training data.
+  Swedish tax planning for enskild firma (sole proprietorship). Covers aktiv vs passiv näringsverksamhet (egenavgifter 28,97% vs SLP 24,26%), räntefördelning (IL 33 kap, positiv SLR+6, negativ SLR+1, kapitalunderlag, sparat fördelningsbelopp), periodiseringsfond EF (30%, no schablonintäkt), expansionsfond (IL 34 kap, 20,6%, 125,94% tak), ersättningsfond (IL 31 kap), kvittning underskott (IL 62:3, 100k cap), inkomstuppdelning familj (IL 60 kap, medhjälpande make), ackumulerad inkomst (IL 66 kap), egenavgifter/SGI/PGI, pensionssparavdrag, EF-vs-AB breakeven. Trigger on enskild firma skatteplanering, näringsidkare, räntefördelning, expansionsfond, ersättningsfond, aktiv/passiv näringsverksamhet, kvittning underskott näring, inkomstuppdelning familj, ackumulerad inkomst, EF vs AB, NE-bilaga, sparat fördelningsbelopp, kapitalunderlag, expansionsskatt, medhjälpande make. For AB use swedish-tax-planning. Always use over training data.
 ---
 
 # Swedish Tax Planning for Enskild Firma (Skatteplanering EF)
@@ -20,12 +20,12 @@ This SKILL.md contains the decision framework, key rates, and interactions. Deta
 |---|---|
 | `references/aktiv-passiv-naringsverksamhet.md` | Aktiv vs passiv classification, tredjedelsregeln (500 h), aktivitetsregeln, huvudsaklighetsregeln, konsekvenser för egenavgifter/SLP/JSA/SGI/PGI, rättsfall |
 | `references/rantefordelning-planning.md` | Positiv/negativ räntefördelning, IL 33 kap, kapitalunderlag, breakeven analysis, sparat fördelningsbelopp, övergångspost, makar, when räntefördelning is *not* worth using |
-| `references/periodiseringsfond-expansionsfond-ef.md` | P-fond EF (30%, no schablonintäkt), expansionsfond (IL 34 kap, 20,6%, 128,21% kapitalunderlagstak), interactions, R29/R30/R34/R35 NE-bilaga |
+| `references/periodiseringsfond-expansionsfond-ef.md` | P-fond EF (30%, no schablonintäkt), expansionsfond (IL 34 kap, 20,6%, 125,94% kapitalunderlagstak), interactions, R29/R30/R34/R35 NE-bilaga |
 | `references/ersattningsfond.md` | IL 31 kap, 4 fund types (inventarier/byggnader/mark/djurlager), utbytestillgångar, expropriation, naturkatastrof, 30% tillägg at återföring |
 | `references/inkomstuppdelning-familj.md` | IL 60 kap, medhjälpande make, gemensam verksamhet, marknadsmässig ersättning, lön till barn 16+, 7-year rule (närstående) |
 | `references/kvittning-underskott.md` | IL 62:3 allmänt avdrag, första 5 åren, 100k cap, kulturarbetare unbounded, slutligt underskott (70%, 3-year split), rullning, EU/EES verksamhet |
 | `references/ackumulerad-inkomst.md` | IL 66 kap, 10-year fördelningstid, 50k spärrgräns, anwendung pension/försäljning/P-fond/expansionsfond återföring |
-| `references/egenavgifter-sgi-pgi-jsa.md` | Egenavgifter 28,97% / SLP 24,26% / 10,21% pensionärer, generell nedsättning 7,5% (max 15k), regional nedsättning, SGI 8 PBB, PGI 7,5 IBB, jobbskatteavdrag, pensionssparavdrag 35% |
+| `references/egenavgifter-sgi-pgi-jsa.md` | Egenavgifter 28,97% / SLP 24,26% / 10,21% pensionärer, generell nedsättning 7,5% (max 15k), regional nedsättning, SGI 10 PBB, PGI 7,5 IBB, jobbskatteavdrag, pensionssparavdrag 35% |
 | `references/ef-vs-ab-breakeven.md` | Marginalskatt + total skatt tables, brytpunkter, lön vs utdelning vs vinst, when to switch EF→AB, både och strategy |
 
 ## Quick decision framework
@@ -81,11 +81,13 @@ Regional nedsättning (Norrlands inland stödområde) 10% on max 180 000 kr (max
 | Positiv (frivillig) | SLR + 6 pp | 7,96% | 8,55% |
 | Negativ (obligatorisk) | SLR + 1 pp | 2,96% | 3,55% |
 
-Gränsbelopp ±50 000 kr kapitalunderlag — under this threshold (in either direction), no räntefördelning may be done.
+Gränsbelopp (2025+, efter prop. 2024/25:1):
+- Positiv RF: kapitalunderlag ≥ 0 kr (50 000 kr-tröskeln **avskaffad** fr.o.m. inkomstår 2025)
+- Negativ RF: triggas vid kapitalunderlag < **−500 000 kr** (höjt från −50 000 kr fr.o.m. inkomstår 2025)
 
 ### Expansionsfond
-- Skatt på avsättning: **20,6%** (expansionsfondsskatt)
-- Tak: **128,21% of kapitalunderlag at current year's end**
+- Skatt på avsättning: **20,6%** (expansionsfondsskatt, synkad med bolagsskatten)
+- Tak: **125,94% of kapitalunderlag at current year's end** (= 100 / 79,4 = gross-up-faktorn vid 20,6% skatt)
 - May not cause underskott in NV
 - On återföring: amount becomes NV income; 20,6% credited against year's tax
 
@@ -98,19 +100,24 @@ Gränsbelopp ±50 000 kr kapitalunderlag — under this threshold (in either dir
 ### Räkenskapsenlig avskrivning på inventarier
 - Huvudregeln: 30% declining balance on (IB + årets inköp – årets försäljningar)
 - Kompletteringsregeln: 20% straight-line per asset over 5 years
-- Förbrukningsinventarier (< half PBB ≈ 29 400 kr 2025, kortidsinventarier ≤ 3 år): direktavdrag
+- Förbrukningsinventarier (< halva PBB: **29 400 kr 2025 / 29 600 kr 2026**, kortidsinventarier ≤ 3 år): direktavdrag. Halva-PBB-gränsen blev enhetlig fr.o.m. 2025 (prop. 2024/25:1) — innan gällde 5 000 kr för många EF.
 
-### PGI/SGI taken (verify annually)
-| Threshold | 2025 |
-|---|---|
-| Lägsta PGI (0,423 PBB) | 24 870 kr |
-| Lägsta SGI (0,24 PBB) | 14 112 kr |
-| Brytpunkt statlig skatt (≤ 65) | ~643 100 kr |
-| Brytpunkt statlig skatt (≥ 65, hel pension) | higher; verify |
-| Max SGI (8 PBB) | 470 400 kr |
-| Max PGI (7,5 IBB) | 604 500 kr |
-| Max föräldrapenninggrundande (10 PBB) | 588 000 kr |
-| Max för 5%-nedsättning egenavgifter (200k underlag) | 200 000 kr |
+### PGI/SGI/brytpunkter (verify annually mot Skatteverket Belopp och procent)
+| Threshold | 2025 | 2026 |
+|---|---|---|
+| Prisbasbelopp (PBB) | 58 800 kr | 59 200 kr |
+| Inkomstbasbelopp (IBB) | 80 600 kr | 83 400 kr |
+| Lägsta PGI (0,423 PBB) | 24 870 kr | 25 042 kr |
+| Lägsta SGI (0,24 PBB) | 14 112 kr | 14 208 kr |
+| Skiktgräns statlig skatt | 625 800 kr | 643 000 kr |
+| Brytpunkt statlig skatt (under pensionsåldersgränsen) | ~643 100 kr | ~660 400 kr |
+| Max SGI (10 PBB) | 588 000 kr | 592 000 kr |
+| Max PGI (7,5 IBB) | 604 500 kr | 625 500 kr |
+| Avgiftstak (8,07 × IBB) | 650 442 kr | 673 038 kr |
+| Max föräldrapenninggrundande (10 PBB) | 588 000 kr | 592 000 kr |
+| Max för 7,5%-nedsättning egenavgifter (200k underlag) | 200 000 kr | 200 000 kr |
+| Halva PBB (förbrukningsinventarier) | 29 400 kr | 29 600 kr |
+| Pensionsåldersgräns (full egenavgift t.o.m. året då man fyller) | 66 år | 67 år |
 
 ## Critical distinction: booked vs declaration-only
 
@@ -135,23 +142,25 @@ This is the largest source of conceptual errors when implementing EF bookkeeping
 |---|---|
 | R11 | Bokfört resultat (samma som förenklat årsbokslut) |
 | R12–R26 | Skattemässiga justeringar (avskrivningar, ej avdragsgill rep., ränta, etc.) |
-| R29 | Återföring av p-fond (oldest year first) |
-| R30 | Räntefördelning (positiv eller negativ) |
-| R31 | Justerad inkomst före P-fond/expansionsfond |
-| R34 | Återföring expansionsfond |
-| R35 | Avsättning ny p-fond |
-| R36 | Återföring expansionsfond i NV |
-| R37 | Ökning av expansionsfond |
+| R29 | Överskott före räntefördelning |
+| R30 | Positiv räntefördelning (till INK1 p.11.1, inkomst av kapital) |
+| R31 | Negativ räntefördelning (till INK1 p.11.2, avdrag i kapital) |
+| R32 | Återföring av periodiseringsfond (oldest year first) |
+| R33 | Överskott före avsättning till periodiseringsfond |
+| R34 | Avsättning till periodiseringsfond (max 30% av R33) |
+| R35 | Överskott före ökning av expansionsfond |
+| R36 | Återföring av expansionsfond (till INK1 p.12.1) |
+| R37 | Ökning av expansionsfond (till INK1 p.12.2) |
 | R38 | Inkomst före schablonavdrag och sjukpenning |
 | R39 | Tidigare års schablonavdrag (positiv) |
 | R40 | Faktiska egenavgifter / SLP (avdrag) |
 | R41/R42 | Sjukpenning hänförlig till NV |
 | R43 | Årets schablonavdrag för egenavgifter |
-| R45 | Inkomst som överförs till tjänst för kvittning (aktiv, nystartad) |
-| R47/R48 | Överskott / underskott av aktiv NV |
-| R49/R50 | Överskott / underskott av passiv NV |
+| R45 | Inkomst som överförs till tjänst för kvittning (aktiv, nystartad) — till INK1 p.14.1 (allmänt avdrag) |
+| R47/R48 | Överskott / underskott av aktiv NV → INK1 p.10.1/p.10.2 |
+| R49/R50 | Överskott / underskott av passiv NV → INK1 p.10.3/p.10.4 |
 
-Field positions reflect the NE 2024 layout — verify exact numbers in current SKV 2161 since they have shifted between years.
+Field positions verified mot officiell NE-bilaga (SKV 2161) inkomstår 2024/2025. Verify mot innevarande års blankett.
 
 ## Skatteflyktslagen and audit triggers for EF
 
@@ -186,4 +195,4 @@ The most valuable patterns for EF:
 - Bokföringslagen (BFL) 1999:1078 — bokföringsskyldighet, K1-tröskel 3 MSEK
 - BFNAR 2006:1 — Enskilda näringsidkare som upprättar förenklat årsbokslut (K1)
 - Lag (1995:575) mot skatteflykt
-- SOU 2014:68 and SOU 2020:50 — proposed simplifications (not enacted)
+- SOU 2020:50 — "Enklare skatteregler för enskild näringsverksamhet". **Delvis genomförd** via prop. 2024/25:1 (ikraft 2025-01-01): RF-trösklar omarbetade (50k slopad / -500k negativ tröskel), halva PBB som inventariegräns. Den större "näringsfond"-idén (samlad ersättning för P-fond+expansionsfond+RF) **ej genomförd**.

--- a/.claude/skills/swedish-ef-skatteplanering/SKILL.md
+++ b/.claude/skills/swedish-ef-skatteplanering/SKILL.md
@@ -62,18 +62,18 @@ The order matters: avskrivningar reduce result, then räntefördelning operates 
 
 ## Core rates and thresholds (verify annually)
 
-### Egenavgifter (inkomstår 2025)
+### Egenavgifter (inkomstår 2025/2026, oförändrade procentsatser)
 | Group | Rate |
 |---|---|
-| Active, 7 karensdagar (standard) | **28,97%** |
+| Active, 7 karensdagar (standard) | **28,97 %** |
 | Active, 1 karensdag | slightly higher |
 | Active, 90 karensdagar | slightly lower |
-| Passive (SLP) | **24,26%** |
-| Pensionär (active or passive, fyllt 65 vid årets ingång eller hel pension hela året) | **10,21%** |
-| Född 1937 eller tidigare | **0%** |
+| Passive (SLP) | **24,26 %** |
+| Pensionär (aktiv eller passiv, året efter pensionsåldersgränsen — 66 år 2025, 67 år 2026) | **10,21 %** |
+| Född 1937 eller tidigare | **0 %** |
 
-Generell nedsättning 7,5% on belopp 40 001 – 200 000 kr (max 15 000 kr/year), automatic.
-Regional nedsättning (Norrlands inland stödområde) 10% on max 180 000 kr (max 18 000 kr/year).
+**Generell nedsättning** 7,5 % av hela avgiftsunderlaget, max 15 000 kr/år. Förutsättning: aktiv NV + underlag > 40 000 kr (40 000-gränsen är en tröskel, inte ett avdragsbelopp — vid underlag 40 001 kr utgår nedsättning på *hela* underlaget). Beräknas automatiskt av Skatteverket.
+Regional nedsättning (Norrlands inland stödområde) 10 % på underlag upp till 180 000 kr (max 18 000 kr/år).
 
 ### Räntefördelningsräntor (anchored to SLR Nov 30 prior year)
 | Type | Formula | 2025 | 2026 |
@@ -110,7 +110,7 @@ Gränsbelopp (2025+, efter prop. 2024/25:1):
 | Lägsta PGI (0,423 PBB) | 24 870 kr | 25 042 kr |
 | Lägsta SGI (0,24 PBB) | 14 112 kr | 14 208 kr |
 | Skiktgräns statlig skatt | 625 800 kr | 643 000 kr |
-| Brytpunkt statlig skatt (under pensionsåldersgränsen) | ~643 100 kr | ~660 400 kr |
+| Brytpunkt statlig skatt (under pensionsåldersgränsen) | 643 100 kr | 660 400 kr |
 | Max SGI (10 PBB) | 588 000 kr | 592 000 kr |
 | Max PGI (7,5 IBB) | 604 500 kr | 625 500 kr |
 | Avgiftstak (8,07 × IBB) | 650 442 kr | 673 038 kr |

--- a/.claude/skills/swedish-ef-skatteplanering/SKILL.md
+++ b/.claude/skills/swedish-ef-skatteplanering/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: swedish-ef-skatteplanering
+description: >
+  Swedish tax planning for enskild firma (sole proprietorship). Covers aktiv vs passiv näringsverksamhet (egenavgifter 28,97% vs SLP 24,26%), räntefördelning (IL 33 kap, positiv SLR+6, negativ SLR+1, kapitalunderlag, sparat fördelningsbelopp), periodiseringsfond EF (30%, no schablonintäkt), expansionsfond (IL 34 kap, 20,6%, 128,21% tak), ersättningsfond (IL 31 kap), kvittning underskott (IL 62:3, 100k cap), inkomstuppdelning familj (IL 60 kap, medhjälpande make), ackumulerad inkomst (IL 66 kap), egenavgifter/SGI/PGI, pensionssparavdrag, EF-vs-AB breakeven. Trigger on enskild firma skatteplanering, näringsidkare, räntefördelning, expansionsfond, ersättningsfond, aktiv/passiv näringsverksamhet, kvittning underskott näring, inkomstuppdelning familj, ackumulerad inkomst, EF vs AB, NE-bilaga, sparat fördelningsbelopp, kapitalunderlag, expansionsskatt, medhjälpande make. For AB use swedish-tax-planning. Always use over training data.
+---
+
+# Swedish Tax Planning for Enskild Firma (Skatteplanering EF)
+
+Developer-facing compliance reference for implementing Swedish tax planning tools for **enskild näringsverksamhet (sole proprietorships)**. Covers the unique tax mechanisms available to physical persons running a business directly, their interactions, and compliance requirements.
+
+For **aktiebolag (AB)** tax planning (periodiseringsfond AB, 3:12, koncernbidrag, etc), use the sister skill `swedish-tax-planning` instead. The mechanisms are fundamentally different — EF is taxed on the owner's personal Inkomstdeklaration 1 + NE-bilaga at marginal rates including egenavgifter, whereas AB pays bolagsskatt and the owner separately.
+
+## How to use this skill
+
+This SKILL.md contains the decision framework, key rates, and interactions. Detailed rules, calculations, and worked examples live in `references/`. Read the relevant reference file when you need depth.
+
+### Reference files
+
+| File | When to read |
+|---|---|
+| `references/aktiv-passiv-naringsverksamhet.md` | Aktiv vs passiv classification, tredjedelsregeln (500 h), aktivitetsregeln, huvudsaklighetsregeln, konsekvenser för egenavgifter/SLP/JSA/SGI/PGI, rättsfall |
+| `references/rantefordelning-planning.md` | Positiv/negativ räntefördelning, IL 33 kap, kapitalunderlag, breakeven analysis, sparat fördelningsbelopp, övergångspost, makar, when räntefördelning is *not* worth using |
+| `references/periodiseringsfond-expansionsfond-ef.md` | P-fond EF (30%, no schablonintäkt), expansionsfond (IL 34 kap, 20,6%, 128,21% kapitalunderlagstak), interactions, R29/R30/R34/R35 NE-bilaga |
+| `references/ersattningsfond.md` | IL 31 kap, 4 fund types (inventarier/byggnader/mark/djurlager), utbytestillgångar, expropriation, naturkatastrof, 30% tillägg at återföring |
+| `references/inkomstuppdelning-familj.md` | IL 60 kap, medhjälpande make, gemensam verksamhet, marknadsmässig ersättning, lön till barn 16+, 7-year rule (närstående) |
+| `references/kvittning-underskott.md` | IL 62:3 allmänt avdrag, första 5 åren, 100k cap, kulturarbetare unbounded, slutligt underskott (70%, 3-year split), rullning, EU/EES verksamhet |
+| `references/ackumulerad-inkomst.md` | IL 66 kap, 10-year fördelningstid, 50k spärrgräns, anwendung pension/försäljning/P-fond/expansionsfond återföring |
+| `references/egenavgifter-sgi-pgi-jsa.md` | Egenavgifter 28,97% / SLP 24,26% / 10,21% pensionärer, generell nedsättning 7,5% (max 15k), regional nedsättning, SGI 8 PBB, PGI 7,5 IBB, jobbskatteavdrag, pensionssparavdrag 35% |
+| `references/ef-vs-ab-breakeven.md` | Marginalskatt + total skatt tables, brytpunkter, lön vs utdelning vs vinst, when to switch EF→AB, både och strategy |
+
+## Quick decision framework
+
+### Step 1: Is the verksamhet aktiv or passiv?
+
+This is the most important classification. It determines:
+- **Egenavgifter (28,97%) vs SLP (24,26%)** — actually SLP is higher than active egenavgifter when nedsättning applies up to 200k
+- **SGI and PGI eligibility** (only aktiv gives sjukpenning/pension rights)
+- **Jobbskatteavdrag** (only aktiv)
+- **Pensionssparavdrag** (only aktiv)
+- **Kvittning av underskott mot tjänst** (only aktiv + nystartad)
+
+Rules (cumulative, any one suffices):
+- **Aktivitetsregeln**: own work > one-third of full-time (≥ 500 h/year)
+- **Huvudsaklighetsregeln**: at consultant + fastighet split, the smaller verksamhet pulls into aktiv if criteria met
+- **Skogsägare special case**: RÅ 2002 ref 15 — own labor counts even at low hours
+
+See [[aktiv-passiv-naringsverksamhet]].
+
+### Step 2: Compute kapitalunderlag for räntefördelning AND expansionsfond
+
+The same kapitalunderlag concept (tillgångar minus skulder at year-end of *previous* year for räntefördelning, current year for expansionsfond takbelopp) drives both. Always compute it even if not using räntefördelning — it can be carried forward as sparat fördelningsbelopp.
+
+### Step 3: Year-end optimization sequence for EF
+
+1. **Avskrivningar på inventarier** — räkenskapsenlig avskrivning 30% huvudregel + 20% kompletteringsregel, choose lowest
+2. **Räntefördelning** — apply positiv only if SLR+6 yields net benefit (often NOT worth it for pensionärer or below brytpunkt; see [[rantefordelning-planning]])
+3. **Periodiseringsfond** — up to 30% of skattemässig vinst, no schablonintäkt for fysiska personer
+4. **Expansionsfond** — for low-tax retention at 20,6%; only if kapitalunderlag supports it
+5. **Egenavgifter schablonavdrag** — 25% standard, 10% pensionärer, 20% SLP
+
+The order matters: avskrivningar reduce result, then räntefördelning operates on that, then P-fond cap is 30% of (result after räntefördelning + återföring P-fond +/- expansionsfond), and expansionsfond may not exceed kapitalunderlag tak.
+
+## Core rates and thresholds (verify annually)
+
+### Egenavgifter (inkomstår 2025)
+| Group | Rate |
+|---|---|
+| Active, 7 karensdagar (standard) | **28,97%** |
+| Active, 1 karensdag | slightly higher |
+| Active, 90 karensdagar | slightly lower |
+| Passive (SLP) | **24,26%** |
+| Pensionär (active or passive, fyllt 65 vid årets ingång eller hel pension hela året) | **10,21%** |
+| Född 1937 eller tidigare | **0%** |
+
+Generell nedsättning 7,5% on belopp 40 001 – 200 000 kr (max 15 000 kr/year), automatic.
+Regional nedsättning (Norrlands inland stödområde) 10% on max 180 000 kr (max 18 000 kr/year).
+
+### Räntefördelningsräntor (anchored to SLR Nov 30 prior year)
+| Type | Formula | 2025 | 2026 |
+|---|---|---|---|
+| Positiv (frivillig) | SLR + 6 pp | 7,96% | 8,55% |
+| Negativ (obligatorisk) | SLR + 1 pp | 2,96% | 3,55% |
+
+Gränsbelopp ±50 000 kr kapitalunderlag — under this threshold (in either direction), no räntefördelning may be done.
+
+### Expansionsfond
+- Skatt på avsättning: **20,6%** (expansionsfondsskatt)
+- Tak: **128,21% of kapitalunderlag at current year's end**
+- May not cause underskott in NV
+- On återföring: amount becomes NV income; 20,6% credited against year's tax
+
+### Periodiseringsfond
+- Tak: **30% of skattemässigt resultat** (vs 25% for AB)
+- 6-year mandatory reversal (FIFO)
+- **NO schablonintäkt** for fysiska personer
+- NE-bilaga only (R34/R35), never booked
+
+### Räkenskapsenlig avskrivning på inventarier
+- Huvudregeln: 30% declining balance on (IB + årets inköp – årets försäljningar)
+- Kompletteringsregeln: 20% straight-line per asset over 5 years
+- Förbrukningsinventarier (< half PBB ≈ 29 400 kr 2025, kortidsinventarier ≤ 3 år): direktavdrag
+
+### PGI/SGI taken (verify annually)
+| Threshold | 2025 |
+|---|---|
+| Lägsta PGI (0,423 PBB) | 24 870 kr |
+| Lägsta SGI (0,24 PBB) | 14 112 kr |
+| Brytpunkt statlig skatt (≤ 65) | ~643 100 kr |
+| Brytpunkt statlig skatt (≥ 65, hel pension) | higher; verify |
+| Max SGI (8 PBB) | 470 400 kr |
+| Max PGI (7,5 IBB) | 604 500 kr |
+| Max föräldrapenninggrundande (10 PBB) | 588 000 kr |
+| Max för 5%-nedsättning egenavgifter (200k underlag) | 200 000 kr |
+
+## Critical distinction: booked vs declaration-only
+
+EF differs sharply from AB on which items are booked vs only entered on NE-bilagan:
+
+| Item | Booked in räkenskaperna? | Where it lives |
+|---|---|---|
+| Räntefördelning | NEVER | NE sid 2 R30/R31 |
+| Periodiseringsfond EF | NEVER (per BFNAR 2006:1 / K1) | NE sid 2 R34/R35 |
+| Expansionsfond | NEVER (per K1) | NE sid 2 R36/R37 |
+| Ersättningsfond | YES (avsättning bokförs); resterande hanteras i deklaration | Bokfört + NE |
+| Egenavgifter schablonavdrag | NEVER | NE sid 2 R43, justering R39/R40 |
+| Skatt på årets resultat | NEVER (personal tax) | Inte i bokföringen |
+| Inventarieavskrivning | YES (8851/1229 etc) | Bokfört |
+| Förenklat årsbokslut U1–U4 | Upplysning, ej bokfört | NE-bilaga upplysning |
+
+This is the largest source of conceptual errors when implementing EF bookkeeping software: developers familiar with AB-flows often try to book P-fond/expansionsfond, which is *forbidden* for EF under K1 (BFNAR 2006:1).
+
+## NE-bilaga key field reference (cross-link with swedish-year-end-closing)
+
+| Ruta | Innehåll |
+|---|---|
+| R11 | Bokfört resultat (samma som förenklat årsbokslut) |
+| R12–R26 | Skattemässiga justeringar (avskrivningar, ej avdragsgill rep., ränta, etc.) |
+| R29 | Återföring av p-fond (oldest year first) |
+| R30 | Räntefördelning (positiv eller negativ) |
+| R31 | Justerad inkomst före P-fond/expansionsfond |
+| R34 | Återföring expansionsfond |
+| R35 | Avsättning ny p-fond |
+| R36 | Återföring expansionsfond i NV |
+| R37 | Ökning av expansionsfond |
+| R38 | Inkomst före schablonavdrag och sjukpenning |
+| R39 | Tidigare års schablonavdrag (positiv) |
+| R40 | Faktiska egenavgifter / SLP (avdrag) |
+| R41/R42 | Sjukpenning hänförlig till NV |
+| R43 | Årets schablonavdrag för egenavgifter |
+| R45 | Inkomst som överförs till tjänst för kvittning (aktiv, nystartad) |
+| R47/R48 | Överskott / underskott av aktiv NV |
+| R49/R50 | Överskott / underskott av passiv NV |
+
+Field positions reflect the NE 2024 layout — verify exact numbers in current SKV 2161 since they have shifted between years.
+
+## Skatteflyktslagen and audit triggers for EF
+
+EF skatteplanering can raise scrutiny under Lag 1995:575 om skatteflykt when:
+- Switching aktiv/passiv classification opportunistically (e.g., to abuse 5-year kvittningsregeln)
+- Inkomstuppdelning between makar that doesn't reflect actual arbetsinsats or kapitalinsats
+- Sudden growth of kapitalunderlag through tillfälliga kapitaltillskott (only varaktiga tillskott count, IL 33 kap 6 §)
+- Large expansionsfond avsättning followed by quick liquidation of verksamheten
+
+## Multi-year planning horizon
+
+The most valuable patterns for EF:
+1. **Build kapitalunderlag steadily** — every kr of varaktig egen insättning grows räntefördelning room *and* expansionsfond tak in perpetuity
+2. **Use P-fond for sjukpenninggrundande inkomst leveling** — note P-fond does NOT affect SGI calculation (Försäkringskassan bortser från dispositioner) but DOES affect PGI; see [[egenavgifter-sgi-pgi-jsa]]
+3. **Aktiv classification is gold** — fight for it via timesheet, since it unlocks jobbskatteavdrag (worth up to ~30 000 kr/year), kvittning mot tjänst, lägre egenavgifter, pensionsrätt
+4. **Consider EF→AB transition around brytpunkten** — under brytpunkten EF is usually cheaper than AB; over brytpunkten AB starts to win (see [[ef-vs-ab-breakeven]])
+
+## Out of scope for this skill
+
+- Bokslutsmekanik for EF (förenklat årsbokslut, K1) — covered in `swedish-year-end-closing` `references/k1-forenklat-arsbokslut.md`
+- Specifika bokföringskonton för transaktioner — covered in `swedish-accounting-compliance`
+- Moms-frågor — covered in `swedish-vat`
+- Lön till anställda i EF — covered in `swedish-payroll`
+- Faktureringsregler — covered in `swedish-invoice-compliance`
+- AB-specifik skatteplanering — covered in `swedish-tax-planning`
+
+## Legal sources
+
+- Inkomstskattelagen (IL) 1999:1229, especially kap 13 (NV), 14 (rörelse), 18 (inventarier), 30 (P-fond), 31 (ersättningsfond), 33 (räntefördelning), 34 (expansionsfond), 60 (inkomstuppdelning familj), 62 (allmänna avdrag), 66 (ackumulerad inkomst)
+- Socialavgiftslagen (SAL) 2000:980
+- Lagen (1990:659) om särskild löneskatt på vissa förvärvsinkomster
+- Bokföringslagen (BFL) 1999:1078 — bokföringsskyldighet, K1-tröskel 3 MSEK
+- BFNAR 2006:1 — Enskilda näringsidkare som upprättar förenklat årsbokslut (K1)
+- Lag (1995:575) mot skatteflykt
+- SOU 2014:68 and SOU 2020:50 — proposed simplifications (not enacted)

--- a/.claude/skills/swedish-ef-skatteplanering/references/ackumulerad-inkomst.md
+++ b/.claude/skills/swedish-ef-skatteplanering/references/ackumulerad-inkomst.md
@@ -1,0 +1,202 @@
+# Ackumulerad Inkomst
+
+## Legal basis
+
+- IL 66 kap (Särskild skatteberäkning för ackumulerad inkomst) — full chapter
+- Gäller endast fysiska personer och dödsbon, inte juridiska personer
+
+## Purpose
+
+Ackumulerad inkomst (AI) is en **särskild skatteberäkning** för att undvika tröskeleffekter vid den progressiva beskattningen of inkomster som tjänats in över flera år men betalats ut **ett enstaka år**.
+
+Without AI, en näringsidkare som upphör med verksamheten och måste återföra 600 000 kr i periodiseringsfonder samma år får hela 600 000 kr beskattat med toppen av progressivskalan (52% statlig skatt över brytpunkten + egenavgifter). Med AI, beloppet sprids tillbaka tilL åren det "egentligen" tjänats in, och skatten beräknas som om det fördelats över de åren.
+
+Note that AI **does NOT spread the income across years for SGI/PGI** — those use the actual deklarerade inkomsten av NV in each respektive year. AI affects only **statlig inkomstskatt**, inte kommunal, egenavgifter, eller socialavgifter.
+
+## Spärregler (cumulative — all must be true)
+
+1. **Något av fördelningsåren ska ha haft beskattningsbar inkomst UNDER brytpunkten för statlig inkomstskatt** under det aktuella året. If you were over brytpunkten all hela fördelningstiden, AI saves nothing.
+2. **Den beskattningsbara inkomsten inklusive den ackumulerade inkomsten måste överstiga brytpunkten med minst 50 000 kr** under det aktuella året (= you actually paid statlig skatt on at least 50 000 kr extra)
+3. **Den ackumulerade inkomsten måste vara minst 50 000 kr**
+
+Brytpunkten 2025: ca 643 100 kr (verify with current SKV value).
+
+For pensionärer (≥ 65 år vid årets ingång), the brytpunkt is higher. Beräkningen anpassas till deras höjda brytpunkt.
+
+## Fördelningstiden (allocation period)
+
+The ackumulerade inkomsten is divided by **antal år** som den intjänats för:
+- Min: 2 år (om bara delar av två år)
+- Max: **10 år**
+- Om svårt att utreda → presumeras **3 år**
+
+If the inkomsten har tjänats över t.ex. 7 år, divisorn är 7. Inkomsten delas i 7 lika delar (en per år), och dessa läggs på den **genomsnittliga förvärvsinkomsten** för alla 7 fördelningsåren. På denna nya totalinkomst beräknas statlig skatt; skatteminskningen vs scenario utan AI är AI-effekten.
+
+Skattetabellsåren justeras efter skiktgränsens förändring i tiden, but skattesatsen för **aktuella beskattningsåret** används.
+
+## Skatteberäkningen i praktiken
+
+Skatteverket gör **inte** beräkningen automatiskt. Du måste **begära** ackumulerad inkomst:
+- Antingen vid den ordinarie deklarationen (skriv under *Övriga upplysningar* eller på särskild bilaga)
+- Eller via begäran inom 5 år efter deklarationsåret (om man missar tillfället)
+- Innehåll: vad slags inkomst, beloppet, antal år som inkomsten hör till samt motivering varför
+
+If the deklarerad inkomst senare ändras (eftertaxering, omprövning) → ansökan om AI kan lämnas inom **ett år från det beslutet** lämnades.
+
+## Typer av inkomster som kan vara AI
+
+### Före eller efter ordinarie utbetalning
+
+AI omfattar inkomster du har fått:
+- **I efterskott** (t.ex. ett engångsbelopp för en pensionsförmån som hör till tidigare år)
+- **I förskott** (t.ex. en engångsroyalty för flera framtida år)
+
+Inkomsten **måste höra till flera år**. En inkomst som hör till ett enda år, även om utbetalningen sker ett senare år, är inte AI.
+
+> "Om en inkomst har tjänats in under ett visst år men har betalats ut (eller kan disponeras) först under ett senare år, är det inte ackumulerad inkomst."
+
+### Vetenskaplig, litterär eller konstnärlig verksamhet
+
+- Författare, konstnärer, vetenskapsmän, arkitekter (knutna till person)
+- Inkomster som inte satts in på upphovsmannakonto
+- Royaltybelopp för flera år utbetalda på en gång
+- Försäljning vid utställning där produktionstiden flera år
+
+Inte AI för: regulier royalty varje år, tantieme per bok varje år.
+
+### Försäljning av rättigheter
+
+- Hyresrätt-överlåtelse (med kontant ersättning)
+- Varumärken-, företagsnamns-, goodwill-rättigheter
+- Engångsersättning för att flytta från lokal i förtid
+
+### Försäljning eller utrangering av inventarier vid avveckling
+
+- Försäljning av inventarier som del av avveckling av verksamheten
+- Försäkringsersättning jämställs om ersättningsfond inte används
+
+### Periodiseringsfond och ersättningsfond — vid upphörande
+
+- Återföring av P-fond pga verksamhets-upphörande får räknas som AI **om de återförda P-fonderna hör till minst 2 beskattningsår**
+- Återföring av ersättningsfond pga överlåtelse / nedläggning samma sak
+
+### Expansionsfond — vid nedläggning till noll
+
+- Om expansionsfond minskas till noll och denna avveckling sker pga verksamhets-upphörande → den NV-inkomst som detta medför kan räknas som AI
+- Krav: expansionsfonden hör till minst 2 beskattningsår
+
+### Stipendier (begränsat)
+
+Stipendier av kulturell prägel = oftast inte AI (engångserkänsla, inte arbetsinsats). Pliktstipendier som betalas högst 2 år i rad är **skattefria** alltid (då blir AI inte aktuellt).
+
+### Ingenjörer m.fl.
+
+Engångsersättning vid överlåtelse av patenträtt kan vara AI om royalty utbetalts för flera år på en gång.
+
+### Skadestånd / försäkringsutbetalningar
+
+Avbrottsförsäkring som ersätter förlust av inkomst för flera år: AI möjligt.
+
+## Worked example
+
+> Slutåret återförs alla P-fonder på 600 000 kr (6 årigtgammal P-fond). Näringsidkaren har också aktuell anställning med 350 000 kr lön samma år. Total förvärvsinkomst aktuellt år: 950 000 kr (= 350k lön + 600k P-fond-återföring).
+>
+> Utan AI: skatt på 950 000 kr ≈ 380 000 kr (inkl statlig 20% på ~290k över brytpunkten = 58k extra).
+>
+> Med AI (fördelningstid 6 år):
+> - Förvärvsinkomst de senaste 6 år: i snitt 350 000 kr/år (= lön + lite eget uttag varje år)
+> - 600 000 / 6 = 100 000 kr fördelas på varje av de 6 åren
+> - För varje fördelningsår: ny inkomst = 350k + 100k = 450k → fortfarande under brytpunkten 643k! → ingen statlig skatt
+> - AI sparar därför hela statliga skatt-bompen → ca **40 000–60 000 kr** less skatt
+> - Egenavgifter och kommunal skatt påverkas inte; betalas normalt på alla 600k.
+
+## Pitfalls
+
+1. **Inte begärt AI** — Skatteverket gör inte beräkningen automatiskt
+2. **Inkomsten hör bara till ett år** — då är AI inte tillämplig (vanligt fel)
+3. **Brytpunkten ej justerad för pensionärer** — brytpunkten är högre för pensionärer (≥ 65)
+4. **Glömt att SGI/PGI inte påverkas** — AI är skattetekniskt; sociala avgifter beräknas på faktisk redovisad inkomst per år
+5. **5-årsregeln för efteransökan missad** — efter 5 år är AI-rätten förlorad
+6. **AI på återförda P-fonder som hör till bara 1 år** — kräver minst 2 års fonder
+
+## Implementation checklist for software
+
+- [ ] Track origin years for each P-fond/expansionsfond (för fördelningstid)
+- [ ] Compute provisional skatt with and without AI for verksamhets-upphörande year
+- [ ] Surface AI-recommendation when sum of återförda fonder ≥ 50 000 kr AND user has been under brytpunkten in any of last 10 years
+- [ ] Generate text-snippet for "Övriga upplysningar" i deklarationen with AI-begäran
+- [ ] Save AI-beräkning som dokumentation för revision
+- [ ] Allow re-running for ändrade förhållanden (omprövning inom 5 år)
+
+## Combination strategies
+
+The **strongest** planning use of AI är ihop med:
+
+### Verksamhets-upphörande
+
+- Avveckla over many years (avveckla successivt) → kan göra successiv återföring av P-fond + ny avsättning, så skatten skjuts up successivt → mindre AI-behov men längre stretchning
+- Alternativt: avveckla på en gång → större toppinkomst → AI utnyttjar mer
+
+### Sparat fördelningsbelopp (räntefördelning)
+
+- Vid nedläggning kan sparat räntefördelningsbelopp användas mot återförd P-fond och expansionsfond
+- This reduces the NV income from the lump återföring → may eliminate AI-need entirely if sparat fördelning fully covers
+- See [[rantefordelning-planning]] (Ville/Lennart worked examples)
+
+### Income leveling över flera år
+
+- Better than waiting for AI är att **utjämna inkomsten** över åren via P-fond avsättningar/återföringar
+- AI är en räddningsplanka för dåligt planerade upphöranden eller plötsliga inkomster
+- Software borde uppmana till **proaktiv** utjämning rather than reaktiv AI
+
+## Pensionssparavdrag — relaterad fråga för EF
+
+Aktiva näringsidkare får göra **pensionssparavdrag** för pensionssparande, vilket också kan användas för att utjämna inkomst.
+
+### Storlek
+
+- **35% av årets eller föregående års inkomst** (max 10 prisbasbelopp ≈ 588 000 kr 2025)
+- Underlaget: inkomsten av aktiv NV **efter räntefördelning, P-fond och expansionsfond**
+- Krav: aktivt bedriven verksamhet *under beskattningsåret*
+- Avdraget får inte överstiga avsättning till pensionsförsäkring eller IPS
+
+### Särskild löneskatt 24,26% på avdraget
+
+På det avdragna beloppet betalas SLP 24,26% (för pensionsförmåner är detta intäkten för Pensionsmyndigheten).
+
+### NE-rad
+
+- R38 = Resultat före pensionssparavdrag
+- R39 = Pensionssparavdrag (positivt)
+- R45/47-48 = slutgiltigt resultat
+
+### Worked example (PDF "Olle")
+
+- Underlag (efter räntefördelning, P-fond, expansionsfond): 834 286 kr
+- Pensionssparavdrag 35% av 834 286 = 292 000 kr
+- Without pensionssparavdrag: skatt+egenavgifter på 834 286 = 363 960 kr
+- With: skatt+egenavgifter på (834 286 − 292 000) + särskild löneskatt 24,26% × 292 000 = 266 532 kr
+- **Net minskning: 97 428 kr**, dvs 33% sänkning av skatt+egenavgifter
+- Olle's pensionsgrundande inkomst ändras inte (han slår i taket)
+
+### PDF caveat — pensionssparavdrag rarely lönar sig
+
+> "Mitt argument mot pensionsförsäkringarna är de höga avgifterna. Dels betalar du avgifter för de underliggande fonderna, dels en förvaltningsavgift för själva försäkringen."
+>
+> "I en lågränteekonomi som vi nu är inne i, blir det lätt så att avkastningen på ditt kapital i pensionsförsäkringen inte ens täcker försäkringsbolagets avgifter (som baseras på kapitalet och inte på avkastningen) och därmed blir tillväxten negativ och du förlorar pengar."
+
+Recommendation: pensionssparavdrag is en sista utväg om man **inte** har annan sätt att spara med samma skattefördelar.
+
+### Ingen pensionssparavdrag i passiv NV
+
+Bara aktiv NV ger pensionssparavdrag. En annan anledning att klassificera sig som aktiv.
+
+### Sparat avdrag
+
+If avdragsutrymmet (35%) inte används till fullo i ett år, resterande del **kan sparas till nästa år** (engångseffekt — kan bara sparas ett år, sedan förloras).
+
+### Köpa ikapp vid nedläggning
+
+Vid nedläggning av verksamheten kan Skatteverket medge **högre pensionssparavdrag** ("köpa ikapp pension") om man inte haft betryggande pensionsskydd. Dispens krävs. Max: 10 PBB × antalet år driftsamhället bedrivits (högst 10 år).
+
+See also [[periodiseringsfond-expansionsfond-ef]] (interaction with underlag för pensionssparavdrag), [[egenavgifter-sgi-pgi-jsa]] (SLP 24,26% — kostnaden of pensionssparavdrag), and [[ef-vs-ab-breakeven]] (pension as a planning alternative).

--- a/.claude/skills/swedish-ef-skatteplanering/references/ackumulerad-inkomst.md
+++ b/.claude/skills/swedish-ef-skatteplanering/references/ackumulerad-inkomst.md
@@ -9,19 +9,25 @@
 
 Ackumulerad inkomst (AI) is en **särskild skatteberäkning** för att undvika tröskeleffekter vid den progressiva beskattningen of inkomster som tjänats in över flera år men betalats ut **ett enstaka år**.
 
-Without AI, en näringsidkare som upphör med verksamheten och måste återföra 600 000 kr i periodiseringsfonder samma år får hela 600 000 kr beskattat med toppen av progressivskalan (52% statlig skatt över brytpunkten + egenavgifter). Med AI, beloppet sprids tillbaka tilL åren det "egentligen" tjänats in, och skatten beräknas som om det fördelats över de åren.
+Utan AI får en näringsidkare som upphör med verksamheten och måste återföra 600 000 kr i periodiseringsfonder hela återföringen beskattad det året — med total marginalskatt som ofta hamnar runt 52 % inklusive **statlig inkomstskatt 20 % över skiktgränsen** + kommunalskatt + egenavgifter. Med AI sprids beloppet tillbaka till åren det "egentligen" tjänats in, och statliga skatten beräknas som om det fördelats över de åren.
 
-Note that AI **does NOT spread the income across years for SGI/PGI** — those use the actual deklarerade inkomsten av NV in each respektive year. AI affects only **statlig inkomstskatt**, inte kommunal, egenavgifter, eller socialavgifter.
+Note that AI **does NOT spread the income across years for SGI/PGI** — those use the actual deklarerade inkomsten av NV in each respektive year. AI affects only **statlig inkomstskatt** (20 %-skiktet), inte kommunal, egenavgifter, eller socialavgifter.
+
+## Terminologi: skiktgräns vs brytpunkt
+
+- **Skiktgräns**: gränsen i **beskattningsbar förvärvsinkomst** (efter grundavdrag) där statlig inkomstskatt 20 % börjar tas ut. 2025: **625 800 kr**. 2026: **643 000 kr**.
+- **Brytpunkt**: motsvarande gräns i **bruttoinkomst** (före grundavdrag) — vad lönen faktiskt behöver vara för att du ska börja betala statlig skatt. 2025: ca 643 100 kr. 2026: ca 660 400 kr.
+- AI-spärregeln nedan använder **beskattningsbar inkomst** (alltså skiktgränsen, inte brytpunkten).
 
 ## Spärregler (cumulative — all must be true)
 
-1. **Något av fördelningsåren ska ha haft beskattningsbar inkomst UNDER brytpunkten för statlig inkomstskatt** under det aktuella året. If you were over brytpunkten all hela fördelningstiden, AI saves nothing.
-2. **Den beskattningsbara inkomsten inklusive den ackumulerade inkomsten måste överstiga brytpunkten med minst 50 000 kr** under det aktuella året (= you actually paid statlig skatt on at least 50 000 kr extra)
+1. **Något av fördelningsåren ska ha haft beskattningsbar inkomst UNDER skiktgränsen för statlig inkomstskatt** under det aktuella året. If you were over skiktgränsen hela fördelningstiden, AI saves nothing.
+2. **Den beskattningsbara inkomsten inklusive den ackumulerade inkomsten måste överstiga skiktgränsen med minst 50 000 kr** under det aktuella året (= you actually paid statlig skatt på minst 50 000 kr extra)
 3. **Den ackumulerade inkomsten måste vara minst 50 000 kr**
 
-Brytpunkten 2025: ca 643 100 kr (verify with current SKV value).
+Skiktgränsen 2025: **625 800 kr**. 2026: **643 000 kr**.
 
-For pensionärer (≥ 65 år vid årets ingång), the brytpunkt is higher. Beräkningen anpassas till deras höjda brytpunkt.
+For pensionärer (året efter pensionsåldersgränsen — 66 år 2025, 67 år 2026), skiktgränsen är högre pga förhöjt grundavdrag. Beräkningen anpassas till deras höjda brytpunkt.
 
 ## Fördelningstiden (allocation period)
 
@@ -97,24 +103,32 @@ Engångsersättning vid överlåtelse av patenträtt kan vara AI om royalty utbe
 
 Avbrottsförsäkring som ersätter förlust av inkomst för flera år: AI möjligt.
 
-## Worked example
+## Worked example — strukturell
 
-> Slutåret återförs alla P-fonder på 600 000 kr (6 årigtgammal P-fond). Näringsidkaren har också aktuell anställning med 350 000 kr lön samma år. Total förvärvsinkomst aktuellt år: 950 000 kr (= 350k lön + 600k P-fond-återföring).
->
-> Utan AI: skatt på 950 000 kr ≈ 380 000 kr (inkl statlig 20% på ~290k över brytpunkten = 58k extra).
->
-> Med AI (fördelningstid 6 år):
-> - Förvärvsinkomst de senaste 6 år: i snitt 350 000 kr/år (= lön + lite eget uttag varje år)
-> - 600 000 / 6 = 100 000 kr fördelas på varje av de 6 åren
-> - För varje fördelningsår: ny inkomst = 350k + 100k = 450k → fortfarande under brytpunkten 643k! → ingen statlig skatt
-> - AI sparar därför hela statliga skatt-bompen → ca **40 000–60 000 kr** less skatt
-> - Egenavgifter och kommunal skatt påverkas inte; betalas normalt på alla 600k.
+Setup: vid avveckling återförs P-fonder på 600 000 kr (intjänade över 6 år). Lön samma år: 350 000 kr. Total förvärvsinkomst aktuellt år: 950 000 kr.
+
+```
+utan_AI:
+  beskattningsbar_inkomst ≈ 950 000 − grundavdrag → tydligt över skiktgränsen 625 800 kr (2025)
+  statlig_skatt = 20 % × (beskattningsbar − skiktgräns) ≈ 65 000 kr (extra)
+  + kommunalskatt + egenavgifter på återföringen
+  total ≈ 380 000 kr
+
+med_AI (fördelningstid 6 år):
+  per_år = 600 000 / 6 = 100 000 kr
+  hypotetisk_årsinkomst = 350 000 + 100 000 = 450 000 kr  → under skiktgränsen alla 6 åren
+  statlig_skatt_per_år = 0 (under skiktgräns)
+  totalt: kommunalskatt + egenavgifter på återföringen oförändrade
+  besparing = ~40 000–60 000 kr (= helt statlig skatt-bortfall)
+```
+
+Princip: AI är värt-att-räkna-på närhelst (a) ackumulerad inkomst ≥ 50 000 kr, (b) ett eller flera fördelningsår låg under skiktgränsen, OCH (c) aktuella året + ackumulerade beloppet driver över skiktgränsen med minst 50 000 kr. AI påverkar bara statlig skatt, inte kommunal eller egenavgifter.
 
 ## Pitfalls
 
 1. **Inte begärt AI** — Skatteverket gör inte beräkningen automatiskt
 2. **Inkomsten hör bara till ett år** — då är AI inte tillämplig (vanligt fel)
-3. **Brytpunkten ej justerad för pensionärer** — brytpunkten är högre för pensionärer (≥ 65)
+3. **Skiktgränsen ej justerad för pensionärer** — pensionärer (efter pensionsåldersgränsen, 66 år 2025 / 67 år 2026) har förhöjt grundavdrag → högre effektiv skiktgräns
 4. **Glömt att SGI/PGI inte påverkas** — AI är skattetekniskt; sociala avgifter beräknas på faktisk redovisad inkomst per år
 5. **5-årsregeln för efteransökan missad** — efter 5 år är AI-rätten förlorad
 6. **AI på återförda P-fonder som hör till bara 1 år** — kräver minst 2 års fonder
@@ -141,7 +155,7 @@ The **strongest** planning use of AI är ihop med:
 
 - Vid nedläggning kan sparat räntefördelningsbelopp användas mot återförd P-fond och expansionsfond
 - This reduces the NV income from the lump återföring → may eliminate AI-need entirely if sparat fördelning fully covers
-- See [[rantefordelning-planning]] (Ville/Lennart worked examples)
+- See [[rantefordelning-planning]] (sparat fördelningsbelopp-mekanik vid nedläggning)
 
 ### Income leveling över flera år
 
@@ -170,22 +184,24 @@ På det avdragna beloppet betalas SLP 24,26% (för pensionsförmåner är detta 
 - R39 = Pensionssparavdrag (positivt)
 - R45/47-48 = slutgiltigt resultat
 
-### Worked example (PDF "Olle")
+### Pensionssparavdrag — breakeven-exempel
 
-- Underlag (efter räntefördelning, P-fond, expansionsfond): 834 286 kr
-- Pensionssparavdrag 35% av 834 286 = 292 000 kr
-- Without pensionssparavdrag: skatt+egenavgifter på 834 286 = 363 960 kr
-- With: skatt+egenavgifter på (834 286 − 292 000) + särskild löneskatt 24,26% × 292 000 = 266 532 kr
-- **Net minskning: 97 428 kr**, dvs 33% sänkning av skatt+egenavgifter
-- Olle's pensionsgrundande inkomst ändras inte (han slår i taket)
+Setup: aktiv EF, underlag (efter RF, P-fond, expansionsfond) ~834 000 kr, redan över PGI-taket.
 
-### PDF caveat — pensionssparavdrag rarely lönar sig
+| Variabel | Utan pensionssparavdrag | Med 35 % avdrag |
+|---|---|---|
+| NV-beskattad inkomst | 834 000 | 834 000 − 292 000 = 542 000 |
+| Skatt + egenavgifter NV-delen | ~364 000 | ~169 000 |
+| Särskild löneskatt 24,26 % × 292 000 | 0 | ~70 800 |
+| **Total skattekostnad** | **~364 000** | **~239 800 + sparade pengar** |
 
-> "Mitt argument mot pensionsförsäkringarna är de höga avgifterna. Dels betalar du avgifter för de underliggande fonderna, dels en förvaltningsavgift för själva försäkringen."
->
-> "I en lågränteekonomi som vi nu är inne i, blir det lätt så att avkastningen på ditt kapital i pensionsförsäkringen inte ens täcker försäkringsbolagets avgifter (som baseras på kapitalet och inte på avkastningen) och därmed blir tillväxten negativ och du förlorar pengar."
+Effekt: ~33 % sänkning av skatt+egenavgifter på året, mot priset att 292 000 kr binds i pensionssparande (utbetalas vid pension, beskattas som tjänsteinkomst då). PGI påverkas inte om man redan slår i taket. Lönar sig sällan p.g.a. fondavgifter — se varning nedan.
 
-Recommendation: pensionssparavdrag is en sista utväg om man **inte** har annan sätt att spara med samma skattefördelar.
+### Caveat — pensionssparavdrag lönar sig sällan
+
+Pensionsförsäkringar bär två avgiftsskikt: avgifter i de underliggande fonderna och en förvaltningsavgift för själva försäkringen (oftast kapitalbaserad). Vid låga avkastningsmiljöer kan avgifterna äta upp eller överstiga avkastningen, vilket gör nettotillväxten negativ.
+
+Recommendation: pensionssparavdrag is en sista utväg om man **inte** har annat sätt att spara med samma skattefördelar.
 
 ### Ingen pensionssparavdrag i passiv NV
 

--- a/.claude/skills/swedish-ef-skatteplanering/references/aktiv-passiv-naringsverksamhet.md
+++ b/.claude/skills/swedish-ef-skatteplanering/references/aktiv-passiv-naringsverksamhet.md
@@ -1,0 +1,108 @@
+# Aktiv vs Passiv Näringsverksamhet
+
+## Legal basis
+
+- IL 2 kap 23 § — defines aktiv vs passiv näringsverksamhet
+- IL 12 kap 37 § — aktiv NV gives basis for jobbskatteavdrag
+- IL 59 kap — pensionssparavdrag requires aktiv
+- Socialavgiftslagen (SAL) 2000:980 — egenavgifter on aktiv
+- Lagen (1990:659) om särskild löneskatt — SLP on passiv
+
+## Why the classification matters
+
+This is the most consequential single classification decision for an EF. It cascades into:
+
+| Mechanism | Aktiv | Passiv |
+|---|---|---|
+| Socialavgift on överskott | Egenavgifter 28,97% (with karens 7) | Särskild löneskatt 24,26% |
+| Generell nedsättning 7,5% (max 15 000 kr) | YES on 40 001–200 000 kr | NO |
+| Sjukpenninggrundande inkomst (SGI) | YES | NO |
+| Pensionsgrundande inkomst (PGI) | YES | NO |
+| Föräldrapenninggrundande inkomst | YES | NO |
+| Jobbskatteavdrag (skattereduktion) | YES (worth up to ~30 000 kr/year) | NO |
+| Pensionssparavdrag (35% / 10 PBB) | YES | NO |
+| Kvittning av underskott mot tjänst (nystartad) | YES (first 5 years, capped 100k/år) | NO |
+| Allmänna avdrag rätt | Limited | None |
+
+The asymmetry: **SLP (24,26%) is lower than egenavgifter (28,97%)** at first glance, but the active näringsidkare gets nedsättning 7,5% and jobbskatteavdrag and lower marginal tax via grundavdrag and pension contribution savings. The active classification is almost always more favorable except for pure capital-yield businesses.
+
+## Definitions and tests
+
+### Aktivitetsregeln (the activity rule)
+
+You are aktiv if you devote at least **one-third of full-time work** to verksamheten. Skatteverket interprets *full-time* as 1500 hours/year → **threshold ≈ 500 hours/year**.
+
+Quote: *"Du anses ha en aktiv näringsverksamhet om du ägnar sysslorna i verksamheten minst en tredjedel av den tid som går åt till en vanlig anställning på heltid."*
+
+### Aktivitetsregeln — alternative (low-hour personal services)
+
+If verksamheten:
+- Is based on your own labor (not on a tillgång)
+- Requires only a limited number of hours
+
+then it counts as aktiv even below 500 h. Example: a konsult who runs the konsultrörelse parallel to an employment, where the labor is the core asset, is aktiv regardless of hour count.
+
+This rule does NOT apply if the inkomst is essentially capital yield from a tillgång (rental property, lantbruk where the soil produces the income).
+
+### Huvudsaklighetsregeln (the primary activity rule)
+
+If you run multiple verksamheter (e.g., one konsult + one hyresfastighet), they are aggregated into a single näringsverksamhet (en näringskälla). The aktiv/passiv classification is then made on the *aggregated* verksamhet.
+
+Tested in 4 steps:
+1. Aggregate all delverksamheter into one.
+2. Compute total arbetsinsats.
+3. If under 1/3 (500 h), look at balansomslutningen — is the capital component dominant? If yes → passiv.
+4. If balansomslutningen is *not* significant, judge whether the verksamhet is primarily own labor or capital → aktiv if labor-based.
+
+### Smittoeffekt (does aktiv "infect" passiv?)
+
+Earlier doctrine: yes — if one delverksamhet is aktiv, the aggregated whole becomes aktiv. Modern interpretation: not automatic; samlad bedömning required. But where labor exceeds 500 h in one part, the aggregated whole usually becomes aktiv.
+
+Worked example (from PDF): Erik has a hyresfastighet (~150 h work/year, normally passiv). He starts a fastighetskonsultverksamhet with 400 h work/year. Combined = 550 h, exceeds tredjedelsregeln → aggregated EF becomes aktiv even though the rental income dominates the balansomslutning.
+
+## Important rättsfall
+
+- **RÅ 2002 ref 15** — skogsägare counted as aktiv despite very low hours, because owner performed all required work himself
+- **Kammarrätten i Göteborg, mål 1157-09** — lantbrukare 300-400 h not enough; she had hired in services for heavy mechanical work, so own labor was not the primary input → passiv
+- **Kammarrätten i Göteborg, mål 4392-09** — näringsidkare with hyresfastighet + pelletsanläggning claimed 700 h; domstolen disbelieved the hour count, denied aktiv status
+- **Kammarrätten i Stockholm 3503-11** — if the *only* income is återföring of P-fond from a previously aktiv year, the year counts as **passiv** (no longer earning aktiv income). Likewise an only income consisting of avstämning av föregående års egenavgifter is passiv.
+
+## Tips for implementing software
+
+If you build software that classifies aktiv/passiv:
+- Persist a **timesheet** (`arbetsinsats` per dag eller månad) per verksamhetsår
+- Surface a warning when hours < 500 AND balansomslutning > a threshold (suggesting passiv risk)
+- For *konsultverksamhet* with low hours, flag the aktivitetsregeln-alternativ (labor-based small consultancy)
+- Track aggregate hours across all delverksamheter in the same EF
+- Sjukpenning income classified as aktiv NV income if originally based on aktiv verksamhet (Skatteverket dnr 131 141234-06/111)
+
+## NE-bilaga / INK1 representation
+
+The aktiv/passiv classification appears on **INK1 sid 2**:
+- Ruta **10.1** — överskott aktiv
+- Ruta **10.2** — underskott aktiv
+- Ruta **10.3** — överskott passiv
+- Ruta **10.4** — underskott passiv
+
+And on **NE sid 1** there's a kryssruta for passiv (default is aktiv).
+
+The schablonavdrag on NE sid 2:
+- R43 = **25%** for aktiv (egenavgifter), **20%** for SLP, **10%** for pensionärer
+
+## Common pitfalls
+
+1. **Claiming aktiv without supporting hour log** — Skatteverket may demand a written timesheet under en revision; without one, default is often passiv if hours are below 500
+2. **Forgetting smittoeffekt across delverksamheter** — adding a small konsultrörelse to an existing passiv hyresfastighet can flip the aggregate to aktiv (or vice versa)
+3. **Treating sjukpenning as aktiv when verksamheten was passiv** — sjukpenning inherits the underlying classification, not flipped to aktiv automatically
+4. **Spousal aktiv/passiv mismatch** — for makar driving gemensam verksamhet, the bedömning is normally the *same* for both (IL 60 kap), so if one is aktiv, both are
+5. **Pensionär trap** — for personer födda 1937 or earlier, there is no egenavgift either way (0%), so aktiv vs passiv only matters for SLP if passiv (24,26% pure tax, no förmåner)
+
+## Worked example: which is cheaper?
+
+For a non-pensionär näringsidkare with 100 000 kr överskott:
+- **Aktiv**: 28,97% egenavgift = 28 970 kr; with 7,5% nedsättning on 40 001–100 000 kr (60 000 underlag × 7,5% = 4 500 kr), net egenavgift ≈ 24 470 kr; PLUS jobbskatteavdrag and grundavdrag reduce inkomstskatt by ~17 000 kr.
+- **Passiv**: 24,26% SLP = 24 260 kr; no nedsättning, no jobbskatteavdrag.
+
+Net: aktiv is roughly 15 000–17 000 kr cheaper per year at this income level. Above brytpunkten the gap narrows because nedsättning caps at 200k underlag and JSA tapers off, but aktiv usually still wins unless the verksamhet is purely capital-yield.
+
+See also [[egenavgifter-sgi-pgi-jsa]] for nedsättningar and [[kvittning-underskott]] for the 5-year kvittningsregel that only aktiv (nystartad) gives access to.

--- a/.claude/skills/swedish-ef-skatteplanering/references/aktiv-passiv-naringsverksamhet.md
+++ b/.claude/skills/swedish-ef-skatteplanering/references/aktiv-passiv-naringsverksamhet.md
@@ -3,7 +3,7 @@
 ## Legal basis
 
 - IL 2 kap 23 § — defines aktiv vs passiv näringsverksamhet
-- IL 12 kap 37 § — aktiv NV gives basis for jobbskatteavdrag
+- IL 67 kap 5-9 §§ — aktiv NV gives basis for jobbskatteavdrag (skattereduktion)
 - IL 59 kap — pensionssparavdrag requires aktiv
 - Socialavgiftslagen (SAL) 2000:980 — egenavgifter on aktiv
 - Lagen (1990:659) om särskild löneskatt — SLP on passiv
@@ -58,7 +58,7 @@ Tested in 4 steps:
 
 Earlier doctrine: yes — if one delverksamhet is aktiv, the aggregated whole becomes aktiv. Modern interpretation: not automatic; samlad bedömning required. But where labor exceeds 500 h in one part, the aggregated whole usually becomes aktiv.
 
-Worked example (from PDF): Erik has a hyresfastighet (~150 h work/year, normally passiv). He starts a fastighetskonsultverksamhet with 400 h work/year. Combined = 550 h, exceeds tredjedelsregeln → aggregated EF becomes aktiv even though the rental income dominates the balansomslutning.
+Exempel: hyresfastighet (~150 h/år, isolerat passiv) + ny konsultverksamhet (~400 h/år) i samma EF → kombinerat 550 h, överstiger tredjedelsregeln → hela den sammanslagna EF:n klassas som **aktiv**, även om hyresintäkten dominerar balansomslutningen.
 
 ## Important rättsfall
 
@@ -100,8 +100,8 @@ The schablonavdrag on NE sid 2:
 ## Worked example: which is cheaper?
 
 For a non-pensionär näringsidkare with 100 000 kr överskott:
-- **Aktiv**: 28,97% egenavgift = 28 970 kr; with 7,5% nedsättning on 40 001–100 000 kr (60 000 underlag × 7,5% = 4 500 kr), net egenavgift ≈ 24 470 kr; PLUS jobbskatteavdrag and grundavdrag reduce inkomstskatt by ~17 000 kr.
-- **Passiv**: 24,26% SLP = 24 260 kr; no nedsättning, no jobbskatteavdrag.
+- **Aktiv**: 28,97 % egenavgift = 28 970 kr; nedsättning = 7,5 % × 100 000 = 7 500 kr (nedsättningen tas av hela underlaget när överskott > 40 000 kr; ingen subtraktion av 40 000), netto egenavgift ≈ 21 470 kr; PLUS jobbskatteavdrag och grundavdrag reducerar inkomstskatten ytterligare.
+- **Passiv**: 24,26 % SLP = 24 260 kr; ingen nedsättning, inget jobbskatteavdrag.
 
 Net: aktiv is roughly 15 000–17 000 kr cheaper per year at this income level. Above brytpunkten the gap narrows because nedsättning caps at 200k underlag and JSA tapers off, but aktiv usually still wins unless the verksamhet is purely capital-yield.
 

--- a/.claude/skills/swedish-ef-skatteplanering/references/ef-vs-ab-breakeven.md
+++ b/.claude/skills/swedish-ef-skatteplanering/references/ef-vs-ab-breakeven.md
@@ -27,101 +27,64 @@ For AB-specific skatteplanering (3:12-regler, periodiseringsfond AB, koncernbidr
 | Inlåning till AB | (Ej tillämpligt) | Tillåtet, ränta 30% kapital |
 | 3:12-regler | (Ej tillämpligt) | Tillämpligt vid kvalificerade andelar |
 | Personligt ansvar | Du själv är firman | Knivskarp skiljelinje |
-| Förbudet mot lån från företaget | Ja (utan begränsning) | NEJ (förbjudna lån, max kreditbrott) |
+| Förbudet mot lån från företaget | Ej tillämpligt — du och firman är samma juridiska person, alla uttag är dina egna pengar | **Förbjudna lån** till aktieägare/närstående enligt ABL 21 kap (smitta hela bolaget, brott mot låneförbudet) |
 | Revisor | Aldrig krav | Krav om 2 av: omsättning > 3 MSEK, 3 anställda, balansomslutning > 1,5 MSEK |
 | Bokslut form | Förenklat årsbokslut (K1) om < 3 MSEK | Årsredovisning (K2/K3) alltid |
 | Bolagsstämma | Inte tillämpligt | Krav även för enmans-AB |
 | Sjukpenning | Direkt från Försäkringskassan dag 15+ | Bolaget måste betala sjuklön dag 1-14 |
 | Tantieme | Inte möjligt | Möjligt — flyttar resultat mellan år |
 
-## Marginalskatt + total skatt — TABELLER ur eske
+## Marginalskatt + total skatt — kvalitativ struktur
 
-These are the **core numbers** for the EF vs AB beslut. Reproduced from PDF "Marginalskatt och total skatt" kapitlet. Verify against current SKV-rater.
+Konkreta procentsatser per inkomstnivå varierar mellan inkomstår (JSA-förstärkningar, ändrade brytpunkter, kommunalskattevariationer). Bygg implementationen mot **Skatteverkets aktuella tabeller** + jobbskatteavdragsräknare för exakta värden — det följande är en kvalitativ guide.
 
-### Icke-pensionärer (aktiv EF, 7 karensdagar, 28,97% egenavgifter, kommunalskatt 32,28%)
+### Icke-pensionärer (aktiv EF, 7 karensdagar, 28,97 % egenavgifter, kommun ~32 %)
 
-| Vinst (kr) | Total skatt (%) | Marginalskatt (%) |
+```
+total_skatt_andel(vinst) växer gradvis från ~24 % vid 100 000 kr → ~45 % vid 1 000 000 kr
+marginalskatt(vinst):
+  under skiktgränsen:                 ~32–46 % (lägst vid lägsta inkomster pga JSA)
+  precis över skiktgränsen:           ~46 % + 20 % statlig = ~58–63 %
+  i JSA-utfasningsintervallet (>13,54 PBB):  ~62–65 %  ← marginalskatten "hoppar"
+```
+
+**Praktisk tröskel**: marginalskatten gör ett tydligt hopp uppåt nära 800 000 kr (kombinerad effekt av statlig skattegräns + JSA-utfasning). Över ca 800 000 kr platsar marginalen ~62–65 %.
+
+### Pensionärer (samma EF, men 10,21 % ålderspensionsavgift)
+
+Markant lägre total skatt på samma vinstnivå — typiskt **8–12 procentenheter lägre total skatt** än icke-pensionärer i samma inkomstskikt. Detta är ett av de starkaste skälen att hålla EF i drift även efter pensionsåldersgränsen.
+
+### Brytpunkter och skiktgräns (aktuella)
+
+Se tabellen i [[egenavgifter-sgi-pgi-jsa]] för 2025/2026-värden:
+- Skiktgräns 2025: 625 800 kr / 2026: 643 000 kr (beskattningsbar inkomst)
+- Brytpunkt 2025: ~643 100 kr / 2026: ~660 400 kr (gross-inkomst före grundavdrag)
+- Pensionärer: högre effektiv skiktgräns p.g.a. förhöjt grundavdrag
+
+## "Kvar efter skatt på 100 kr" — kvalitativ jämförelse EF vs AB
+
+Alla värden ungefärliga, för icke-pensionär under brytpunkten:
+
+| Inkomstmetod | Kvar efter skatt per 100 kr | Notering |
 |---|---|---|
-| 100 000 | 24 | 32 |
-| 200 000 | 28 | 33 |
-| 300 000 | 31 | 42 |
-| 400 000 | 34 | 43 |
-| 500 000 | 36 | 43 |
-| 600 000 | 37 | 46 |
-| 700 000 | 39 | 46 |
-| 800 000 | 41 | **61** |
-| 900 000 | 43 | 63 |
-| 1 000 000 | 45 | 63 |
+| EF-vinst under brytpunkten | **60–68 kr** | egenavgifter + kommunal, jobbskatteavdrag |
+| EF + positiv räntefördelning (när tillämpligt) | ~70 kr | flyttar del till kapital (30 %) |
+| AB-lön under brytpunkten | **53–58 kr** | arbetsgivaravgifter 31,42 % + kommunal + jobbskatteavdrag |
+| AB-utdelning inom K10 gränsbelopp | ~62 kr | 20,6 % bolagsskatt + 20 % kapital |
+| AB-utdelning över gränsbelopp (tjänstebeskattad) | ~50 kr | 20,6 % bolagsskatt + marginal-tjänst |
 
-Note: marginalskatten *hoppar* uppåt vid 800 000 kr för icke-pensionärer, sedan platsar runt 63%. Detta beror på utfasning av jobbskatteavdraget kombinerat med skiktgränsen för statlig skatt.
+Pensionärer (10,21 % egenavgift): upp till ~75 kr kvar per 100 kr på låga–medel-inkomster, oavsett EF eller AB-lön. Födda 1937 eller tidigare (0 % avgift): närmare 80 kr kvar.
 
-### Pensionärer (samma verksamhet, men 10,21% egenavgifter)
-
-| Vinst (kr) | Total skatt (%) | Marginalskatt (%) |
-|---|---|---|
-| 100 000 | 16 | 19 |
-| 200 000 | 16 | 19 |
-| 300 000 | 19 | 30 |
-| 400 000 | 22 | 32 |
-| 500 000 | 25 | 38 |
-| 600 000 | 27 | 56 |
-| 700 000 | 32 | 59 |
-| 800 000 | 35 | 64 |
-| 900 000 | 38 | 59 |
-| 1 000 000 | 41 | 64 |
-
-Pensionärer betalar markant lägre skatt än icke-pensionärer på samma vinst — en av de **starkaste skälen** att hålla EF i drift även efter pensionsåldern.
-
-### Brytpunkter (för statlig skatt)
-
-| Group | Brytpunkt 2025 |
-|---|---|
-| Icke-pensionär | ca 643 100 kr (verify) |
-| Pensionär (≥ 65 vid årets ingång, hel pension hela året) | ca 707 200 kr (verify) |
-
-Note 2021 baseline values from PDF: 537 200 kr (under 65) / 596 800 kr (pensionär). Verifying needs current SKV-data.
-
-## Tabellen "Kvar efter skatt på 100 kr"
-
-PDF aggregerar de typiska scenarierna so här:
-
-### Aktiv NV i EF (icke-pensionär, vinst under brytpunkten 537 200 kr 2021)
-
-| Inkomstmetod | Kvar efter skatt på 100 kr intjänad |
-|---|---|
-| Vinst i EF, under brytpunkten (–64 år) | **60–68 kr** |
-| Positiv räntefördelning | **70 kr** |
-
-### Löneuttag från AB (icke-pensionär)
-
-| Inkomstmetod | Kvar efter skatt på 100 kr intjänad |
-|---|---|
-| Löneuttag –64 år | **53–58 kr** |
-| Kapitalbeskattad utdelning (inom gränsbelopp K10) | **62 kr** |
-| Tjänstebeskattad utdelning (över gränsbelopp) | **50 kr** |
-
-### Tolkning
-
-- **Under brytpunkten**: EF *vinner* över AB-lön (60–68 kr vs 53–58 kr) med ca 7–10 kr per intjänad 100 kr → 7–10% bättre
-- **Vid utnyttjande av positiv räntefördelning**: EF ger 70 kr → motsvarar K10-utdelning (62 kr) plus AB-bolagsskatt nedmuttring
-
-### Över brytpunkten
-
-PDF observation: "På inkomster över brytpunkten är vinst-alternativet inte förmånligt utan då är det kapitalbeskattad utdelning som ger bäst skatteeffekt."
-
-So över brytpunkten (statlig skatt 20% extra), AB med kapitalbeskattad K10-utdelning vinner over EF.
-
-### Pensionärer skiljer sig
-
-Pensionärer (10,21% egenavgifter) tjäna upp till ca **75 kr per 100 kr** vid löneuttag från AB, om de utnyttjar utökat JSA för +65-åringar och har en låg pension som komplement. EF för pensionärer ger samma höga retention (eftersom egenavgifterna redan är låga 10,21%). PDF: "Som bäst kan det bli ca 75 kr kvar för ägaren vid löneuttag."
-
-Födda 1937 och tidigare: inga egenavgifter alls → "närmare 80 kr kvar i fickan för privat konsumtion på löner upp till brytpunkten."
+**Tolkning**:
+- Under brytpunkten: EF vinner över AB-lön med ~7–10 kr per 100 kr (~10 % bättre netto)
+- EF med utnyttjad positiv RF: jämförbart med AB:s K10-utdelning
+- Över brytpunkten: AB med K10-utdelning vinner, eftersom statlig skatt 20 % slår igenom på EF-vinst men inte på kapitalbeskattad utdelning
 
 ## När EF generellt är förmånligare än AB
 
 1. **Vinst under brytpunkten** (icke-pensionär)
 2. **Pensionär** med aktiv NV (mycket lägre egenavgifter än AB:s arbetsgivaravgifter)
-3. **Kombinerad förlustverksamhet och vinstverksamhet** — automatisk kvittning inom EF (se [[kvittning-underskott]] Bertil-exempel)
+3. **Kombinerad förlustverksamhet och vinstverksamhet** — automatisk kvittning inom EF (se [[kvittning-underskott]] för räkneexempel)
 4. **Kulturarbetarverksamhet** — fri kvittning av underskott mot tjänst, ingen 5-årsgräns
 5. **Ny start** — kvittning mot tjänst första 5 åren (100k/år)
 6. **62–64-åringar** — har specialgyl: hel allmän pension under hela året → lägre 10,21% egenavgifter även före 65
@@ -136,10 +99,9 @@ Födda 1937 och tidigare: inga egenavgifter alls → "närmare 80 kr kvar i fick
 6. **Behov av att kapitalisera ABFP, försäljning av aktier till externa**
 7. **Inlåning av privata medel till verksamheten** — ABs kan göra inlåning, ge sig själv marknadsmässig ränta (~SLR+1) som beskattas i kapital (30%); EF har bara räntefördelning, vilket är mindre flexibelt
 
-## "Både och" strategy
+## "Både och"-strategy (parallell EF + AB)
 
-PDF rekommendation explicit: 
-> "Ett tips är att du samtidigt har enskild firma och aktiebolag; i många fall är detta faktiskt det bästa alternativet."
+I många fall är det bästa alternativet att driva både EF och AB parallellt — kombinationen ger fördelar som ingetdera ensamt erbjuder.
 
 ### Use cases
 
@@ -177,7 +139,7 @@ A subtle but real fördel för EF:
 - **AB-ägare**: AB:et måste betala sjuklön första 14 dagarna ur egen ficka. Försäkringskassan tar över dag 15+. Försäkringskassan granskar AB:ens ekonomi för att bedöma rimlig SGI → kan vara restriktiva för hög lön
 - **EF-ägare**: Försäkringskassan betalar sjukpenning direkt från dag 8 (efter karenstid 7 dagar). Aldrig sjuklönsperiod ur EF-ekonomin. SGI baseras på NV-inkomsten over senare år.
 
-PDF: "Försäkringskassan kan direkt konstatera vilken månadslön du har och därmed vilken sjukpenning du har rätt till. Men det förekommer att Försäkringskassan granskar bolagets ekonomi för att bedöma om ett visst (högt) löneuttag är en rimlig uthållig nivå."
+För AB-anställda baseras sjukpenningen normalt direkt på månadslönen, men Försäkringskassan kan granska bolagets ekonomi för att bedöma om ett ovanligt högt löneuttag är uthålligt — det kan leda till nedjusterad SGI om resultatet inte motsvarar lönenivån.
 
 ## Inlåning till AB — and parallel concept i EF
 
@@ -233,7 +195,7 @@ Hela verksamheten överförs till AB. Periodiseringsfonder får överföras (om 
 
 Underskott i EF kan **INTE** föras över till AB. Restriktion: tillgångarna förs ut till underpris → uttagsbeskattning frångås → slutligt underskott begränsas.
 
-Detaljerade regler för ombildning: se Björn Lundén-bok "BYTE FRÅN ENSKILD FIRMA TILL AKTIEBOLAG".
+Detaljerade regler för ombildning EF → AB (kontinuitetsregler, kvarvarande P-fond/expansionsfond, övertagande av räkenskapsenlig avskrivning, tröskeleffekter) ligger utanför scope för denna skill.
 
 ## Tabell: snabbjämförelse vid olika vinstnivåer
 
@@ -253,15 +215,20 @@ Crossover for EF advantage: roughly **at brytpunkten** (~640 000 kr 2025). Below
 
 ## Anställning vs EF + bisyssla
 
-PDF subtle case:
+Subtilt mönster: en näringsidkare med AB-konsultverksamhet (~520 000 kr vinst) **plus** parallell EF med passiv hyresfastighet (~100 000 kr förlust/år).
 
-Mannen har anställning (250 000 kr lön) + EF hyresfastighet (passiv).
+```
+option_A: behåll AB+EF separat
+  AB-vinst beskattas högt → ~299 000 kr efter skatt
+  EF-förlust rullas (kan inte kvittas mot AB-vinst)
+  netto efter att täcka förlusten ur beskattade pengar: ~199 000 kr
 
-> "Bertil har också sedan många år en enskild firma (ett hyreshus) som ger en förlust på 100 000 kr varje år. Han tar detta av sina beskattade pengar och har därefter slutligen 299 000 – 100 000 = 199 000 kr kvar av lönen från bolaget."
+option_B: avveckla AB, slå ihop allt i EF
+  sammanlagd EF-vinst = 520 000 − 100 000 = 420 000 kr
+  skatt+egenavgifter ≈ 167 000 kr → ~253 000 kr kvar
 
-Bertil's alternative: skrota AB:et, lägg konsultverksamheten i EF + hyreshuset → sammanlagd vinst 520 000 − 100 000 = 420 000 kr, beskattat i en EF → 253 000 kr kvar.
-
-**Sparing: 54 000 kr/år** by collapsing AB into the existing EF, because the EF kvittar inbyggt mellan delverksamheter.
+besparing ≈ 54 000 kr/år genom intern kvittning mellan delverksamheter i EF
+```
 
 ## Pitfalls
 

--- a/.claude/skills/swedish-ef-skatteplanering/references/ef-vs-ab-breakeven.md
+++ b/.claude/skills/swedish-ef-skatteplanering/references/ef-vs-ab-breakeven.md
@@ -1,0 +1,293 @@
+# EF vs AB — Skattemässig Jämförelse och Brytpunkter
+
+## Purpose
+
+This reference helps decide when an enskild näringsidkare should:
+1. Stay as EF
+2. Ombilda till AB
+3. Run **both EF and AB parallellt** (the "både och" strategy)
+
+The decision involves marginalskatt jämförelser, sociala avgifter, riskhantering, pension/SGI-byggande, och administrativ komplexitet.
+
+For AB-specific skatteplanering (3:12-regler, periodiseringsfond AB, koncernbidrag), use `swedish-tax-planning` (sister skill).
+
+## Den fundamentala olikheten
+
+| Aspekt | EF | AB |
+|---|---|---|
+| Juridisk person | Nej (= du själv) | Ja |
+| Skattesubjekt | Nej (personlig deklaration) | Ja (egen INK2) |
+| Ansvar för skulder | Obegränsat personligt | Begränsat till aktiekapital (25k min) |
+| Föreningssamhetsstruktur | En person (eller makar gemensamt) | 1+ ägare med skilda andelar |
+| Inkomstskatt | Personlig progressiv (29 – 65% inkl egenavgifter) | Bolagsskatt 20,6% + ägarbeskattning |
+| Socialavgift | Egenavgifter 28,97% (aktiv) / SLP 24,26% (passiv) | Arbetsgivaravgifter 31,42% på lön |
+| Periodiseringsfond | 30%, ingen schablonintäkt, ej bokförd | 25%, schablonintäkt, ska bokföras |
+| Expansionsfond | 20,6%, ger lågbeskattad retention | (Inte tillämpligt — använd retention) |
+| Räntefördelning | Tillämpligt (IL 33 kap) | Inte tillämpligt |
+| Inlåning till AB | (Ej tillämpligt) | Tillåtet, ränta 30% kapital |
+| 3:12-regler | (Ej tillämpligt) | Tillämpligt vid kvalificerade andelar |
+| Personligt ansvar | Du själv är firman | Knivskarp skiljelinje |
+| Förbudet mot lån från företaget | Ja (utan begränsning) | NEJ (förbjudna lån, max kreditbrott) |
+| Revisor | Aldrig krav | Krav om 2 av: omsättning > 3 MSEK, 3 anställda, balansomslutning > 1,5 MSEK |
+| Bokslut form | Förenklat årsbokslut (K1) om < 3 MSEK | Årsredovisning (K2/K3) alltid |
+| Bolagsstämma | Inte tillämpligt | Krav även för enmans-AB |
+| Sjukpenning | Direkt från Försäkringskassan dag 15+ | Bolaget måste betala sjuklön dag 1-14 |
+| Tantieme | Inte möjligt | Möjligt — flyttar resultat mellan år |
+
+## Marginalskatt + total skatt — TABELLER ur eske
+
+These are the **core numbers** for the EF vs AB beslut. Reproduced from PDF "Marginalskatt och total skatt" kapitlet. Verify against current SKV-rater.
+
+### Icke-pensionärer (aktiv EF, 7 karensdagar, 28,97% egenavgifter, kommunalskatt 32,28%)
+
+| Vinst (kr) | Total skatt (%) | Marginalskatt (%) |
+|---|---|---|
+| 100 000 | 24 | 32 |
+| 200 000 | 28 | 33 |
+| 300 000 | 31 | 42 |
+| 400 000 | 34 | 43 |
+| 500 000 | 36 | 43 |
+| 600 000 | 37 | 46 |
+| 700 000 | 39 | 46 |
+| 800 000 | 41 | **61** |
+| 900 000 | 43 | 63 |
+| 1 000 000 | 45 | 63 |
+
+Note: marginalskatten *hoppar* uppåt vid 800 000 kr för icke-pensionärer, sedan platsar runt 63%. Detta beror på utfasning av jobbskatteavdraget kombinerat med skiktgränsen för statlig skatt.
+
+### Pensionärer (samma verksamhet, men 10,21% egenavgifter)
+
+| Vinst (kr) | Total skatt (%) | Marginalskatt (%) |
+|---|---|---|
+| 100 000 | 16 | 19 |
+| 200 000 | 16 | 19 |
+| 300 000 | 19 | 30 |
+| 400 000 | 22 | 32 |
+| 500 000 | 25 | 38 |
+| 600 000 | 27 | 56 |
+| 700 000 | 32 | 59 |
+| 800 000 | 35 | 64 |
+| 900 000 | 38 | 59 |
+| 1 000 000 | 41 | 64 |
+
+Pensionärer betalar markant lägre skatt än icke-pensionärer på samma vinst — en av de **starkaste skälen** att hålla EF i drift även efter pensionsåldern.
+
+### Brytpunkter (för statlig skatt)
+
+| Group | Brytpunkt 2025 |
+|---|---|
+| Icke-pensionär | ca 643 100 kr (verify) |
+| Pensionär (≥ 65 vid årets ingång, hel pension hela året) | ca 707 200 kr (verify) |
+
+Note 2021 baseline values from PDF: 537 200 kr (under 65) / 596 800 kr (pensionär). Verifying needs current SKV-data.
+
+## Tabellen "Kvar efter skatt på 100 kr"
+
+PDF aggregerar de typiska scenarierna so här:
+
+### Aktiv NV i EF (icke-pensionär, vinst under brytpunkten 537 200 kr 2021)
+
+| Inkomstmetod | Kvar efter skatt på 100 kr intjänad |
+|---|---|
+| Vinst i EF, under brytpunkten (–64 år) | **60–68 kr** |
+| Positiv räntefördelning | **70 kr** |
+
+### Löneuttag från AB (icke-pensionär)
+
+| Inkomstmetod | Kvar efter skatt på 100 kr intjänad |
+|---|---|
+| Löneuttag –64 år | **53–58 kr** |
+| Kapitalbeskattad utdelning (inom gränsbelopp K10) | **62 kr** |
+| Tjänstebeskattad utdelning (över gränsbelopp) | **50 kr** |
+
+### Tolkning
+
+- **Under brytpunkten**: EF *vinner* över AB-lön (60–68 kr vs 53–58 kr) med ca 7–10 kr per intjänad 100 kr → 7–10% bättre
+- **Vid utnyttjande av positiv räntefördelning**: EF ger 70 kr → motsvarar K10-utdelning (62 kr) plus AB-bolagsskatt nedmuttring
+
+### Över brytpunkten
+
+PDF observation: "På inkomster över brytpunkten är vinst-alternativet inte förmånligt utan då är det kapitalbeskattad utdelning som ger bäst skatteeffekt."
+
+So över brytpunkten (statlig skatt 20% extra), AB med kapitalbeskattad K10-utdelning vinner over EF.
+
+### Pensionärer skiljer sig
+
+Pensionärer (10,21% egenavgifter) tjäna upp till ca **75 kr per 100 kr** vid löneuttag från AB, om de utnyttjar utökat JSA för +65-åringar och har en låg pension som komplement. EF för pensionärer ger samma höga retention (eftersom egenavgifterna redan är låga 10,21%). PDF: "Som bäst kan det bli ca 75 kr kvar för ägaren vid löneuttag."
+
+Födda 1937 och tidigare: inga egenavgifter alls → "närmare 80 kr kvar i fickan för privat konsumtion på löner upp till brytpunkten."
+
+## När EF generellt är förmånligare än AB
+
+1. **Vinst under brytpunkten** (icke-pensionär)
+2. **Pensionär** med aktiv NV (mycket lägre egenavgifter än AB:s arbetsgivaravgifter)
+3. **Kombinerad förlustverksamhet och vinstverksamhet** — automatisk kvittning inom EF (se [[kvittning-underskott]] Bertil-exempel)
+4. **Kulturarbetarverksamhet** — fri kvittning av underskott mot tjänst, ingen 5-årsgräns
+5. **Ny start** — kvittning mot tjänst första 5 åren (100k/år)
+6. **62–64-åringar** — har specialgyl: hel allmän pension under hela året → lägre 10,21% egenavgifter även före 65
+
+## När AB generellt är förmånligare
+
+1. **Vinst över brytpunkten** (statlig skatt 20% extra slår igenom)
+2. **Behov av att samla på sig sparat utdelningsutrymme (K10)** — för framtida säljbar verksamhet
+3. **Behov av begränsat personligt ansvar** (kommersiella skäl)
+4. **Flera ägare som inte är makar/sambor** (EF passar bara en person eller makar)
+5. **Behov av extern finansiering** — bank/investerare ser hellre AB
+6. **Behov av att kapitalisera ABFP, försäljning av aktier till externa**
+7. **Inlåning av privata medel till verksamheten** — ABs kan göra inlåning, ge sig själv marknadsmässig ränta (~SLR+1) som beskattas i kapital (30%); EF har bara räntefördelning, vilket är mindre flexibelt
+
+## "Både och" strategy
+
+PDF rekommendation explicit: 
+> "Ett tips är att du samtidigt har enskild firma och aktiebolag; i många fall är detta faktiskt det bästa alternativet."
+
+### Use cases
+
+#### Hybridmodell 1: Bygga gränsbelopp innan AB tas i bruk fullt
+
+- Start verksamheten i EF (utnyttja 5-årsregeln för kvittning, samla på dig kompetens)
+- Start AB parallellt → börja samla på dig sparat utdelningsutrymme (K10 förenklingsregeln 2,75 IBB / 4 IBB)
+- Om några år: ombilda hela verksamheten till AB med ackumulerat utdelningsutrymme i hand
+
+#### Hybridmodell 2: Konsult i AB + hyresfastighet i EF
+
+- AB driver konsultverksamheten (hög inkomst, K10 + lön kombo)
+- EF driver hyresfastighet (passiv → SLP 24,26%, ingen JSA, eller om aktiv-status: full system)
+- Inkomstkvittning mellan AB och EF är dock inte möjligt direkt — men:
+  - AB:s utgifter och EF:s utgifter är separata; ingen blandning
+  - Personlig deklaration kombinerar dock allt → AB-utdelning + EF-vinst slås ihop för progressivskalan
+  - **Lägg lågmarginalskatt-aktiviteten i EF**, högmarginalskatt-aktiviteten i AB
+
+#### Hybridmodell 3: Kulturarbetare med sidoverksamhet
+
+- Kulturarbetarverksamheten i EF (för kulturarbetarkvittning)
+- Sidoverksamheten (e.g., konsulthantering) i HB → får 5-årsregeln igen
+- AB om man har stor andel ägande och flera samarbetspartner
+
+#### Hybridmodell 4: 62+ med komplementverksamhet
+
+- Lön/pension från eget AB
+- EF parallellt → drar nytta av låga egenavgifter (10,21% från 62 om hel pension hela året, annars 28,97% till 65)
+- Pension är inte JSA-grundande, men aktiv NV-inkomst är → även små belopp aktiv NV ger förhöjt JSA
+
+## Skiljd hantering vid sjukpenning
+
+A subtle but real fördel för EF:
+
+- **AB-ägare**: AB:et måste betala sjuklön första 14 dagarna ur egen ficka. Försäkringskassan tar över dag 15+. Försäkringskassan granskar AB:ens ekonomi för att bedöma rimlig SGI → kan vara restriktiva för hög lön
+- **EF-ägare**: Försäkringskassan betalar sjukpenning direkt från dag 8 (efter karenstid 7 dagar). Aldrig sjuklönsperiod ur EF-ekonomin. SGI baseras på NV-inkomsten over senare år.
+
+PDF: "Försäkringskassan kan direkt konstatera vilken månadslön du har och därmed vilken sjukpenning du har rätt till. Men det förekommer att Försäkringskassan granskar bolagets ekonomi för att bedöma om ett visst (högt) löneuttag är en rimlig uthållig nivå."
+
+## Inlåning till AB — and parallel concept i EF
+
+### AB
+
+- Ägaren får låna ut pengar till AB:et
+- AB betalar marknadsmässig ränta → beskattas hos ägaren i inkomstslaget kapital (**30% skatt**)
+- Marknadsmässig ränta för ett AB med 25 000 kr aktiekapital ≈ SLR + 1 procentenhet (knappast värt besväret)
+- Ej lönebeskattning på räntan; ingen arbetsgivaravgift
+
+### EF
+
+- Ingen motsvarighet — det är **du själv** som driver firman; du kan inte låna ut till dig själv
+- Närmast: räntefördelning (kapitalbeskattning 30% av schablonräntan på kapitalunderlaget)
+- Räntefördelning är dock obligatorisk (alltid beräknas), och kommer med vissa begränsningar (kapitalunderlag-tröskel, etc)
+
+## Uthyrning till AB
+
+EF har en **specifik nackdel** vs AB här:
+
+- Som ägare till ett AB kan du hyra ut **lokal i din bostad** till AB:et och få marknadsmässig hyra som beskattas i inkomstslaget kapital (30%)
+- Som EF-ägare får du INTE hyra ut lokal i din bostad till din EF
+- Istället: schablonavdrag (2 000 / 4 000 kr per år beroende på upplåtelseform) eller faktiska merkostnader
+
+## Tantieme — inte tillgängligt i EF
+
+I AB kan ägaren styra resultatet genom **tantiemavsättning** (vinstrelaterad löneökning, beskattas hos ägaren året efter bolagsstämman):
+- Reducerar AB:ens beskattningsbara resultat aktuella året
+- Beskattas hos ägaren först nästa år (vid utdelningstillfället)
+
+I EF: ingen motsvarighet. Resultatet beskattas alltid hos näringsidkaren personligen samma år.
+
+## Föräldraledighet och föräldrapenninggrundande inkomst
+
+- EF: inkomst av aktiv NV → föräldrapenninggrundande (tak 10 PBB = 588 000 kr 2025)
+- AB: lön + förmåner → föräldrapenninggrundande
+- Hybridfördel: AB-ägare kan dra upp sin lön innan föräldraledighet för att maxa föräldrapenningen (FK kan dock granska)
+
+## Ombildning EF → AB — when to switch
+
+Triggers för att ombilda till AB:
+- **Vinst regelbundet över 800 000 kr** — marginalskatten i EF når 61–63% medan AB-bolagsskatt + K10-utdelning ger 36–40% effektiv
+- **Verksamhet ska säljas i framtid** — AB-aktier kan säljas; EF kan inte
+- **Externa investerare** behöver
+- **Personligt ansvar oacceptabelt** — t.ex. byggverksamhet med stora kontrakt
+- **Flera ägare som inte är makar** — EF passar bara en person + makar; HB möjligt men ofta inte attraktivt
+- **Anställning skapas** — formellt anställningsförhållande lättare i AB
+- **Skenmänsklig profilering** — AB ofta uppfattas som mer seriös av kunder
+
+### Praktisk ombildning
+
+Hela verksamheten överförs till AB. Periodiseringsfonder får överföras (om hela verksamheten eller en verksamhetsgren går över) → aktiekapital måste tillskjutas motsvarande P-fondernas sammanlagda storlek. Expansionsfond kan föras över under specifika villkor (79,4% av fondbeloppet i realtillgångar måste föras med).
+
+Underskott i EF kan **INTE** föras över till AB. Restriktion: tillgångarna förs ut till underpris → uttagsbeskattning frångås → slutligt underskott begränsas.
+
+Detaljerade regler för ombildning: se Björn Lundén-bok "BYTE FRÅN ENSKILD FIRMA TILL AKTIEBOLAG".
+
+## Tabell: snabbjämförelse vid olika vinstnivåer
+
+Per intjänad krona, ungefär (under 65, aktiv, kommunalskatt 32%):
+
+| Vinst (årlig) | EF (vinst) | AB (lön) | AB (utdelning inom K10) |
+|---|---|---|---|
+| 100 000 | 76 kr/100 | 50 kr/100 | (ej K10-möjlighet ofta) |
+| 300 000 | 69 kr/100 | 53 kr/100 | 62 kr/100 (om K10 finns) |
+| 500 000 | 64 kr/100 | 55 kr/100 | 62 kr/100 |
+| 700 000 | 54 kr/100 | 48 kr/100 | 62 kr/100 |
+| 900 000 | 37 kr/100 | 42 kr/100 | 62 kr/100 |
+
+(Approximate — actual depends on specific deduction utilizations.)
+
+Crossover for EF advantage: roughly **at brytpunkten** (~640 000 kr 2025). Below it, EF wins. Above it, AB with K10 wins.
+
+## Anställning vs EF + bisyssla
+
+PDF subtle case:
+
+Mannen har anställning (250 000 kr lön) + EF hyresfastighet (passiv).
+
+> "Bertil har också sedan många år en enskild firma (ett hyreshus) som ger en förlust på 100 000 kr varje år. Han tar detta av sina beskattade pengar och har därefter slutligen 299 000 – 100 000 = 199 000 kr kvar av lönen från bolaget."
+
+Bertil's alternative: skrota AB:et, lägg konsultverksamheten i EF + hyreshuset → sammanlagd vinst 520 000 − 100 000 = 420 000 kr, beskattat i en EF → 253 000 kr kvar.
+
+**Sparing: 54 000 kr/år** by collapsing AB into the existing EF, because the EF kvittar inbyggt mellan delverksamheter.
+
+## Pitfalls
+
+1. **Förutsätta att AB alltid är bättre vid hög vinst** — under brytpunkten EF är ALMOST ALWAYS bättre
+2. **Glömma "både och" möjligheten** — ofta bästa lösningen
+3. **Konvertering till AB innan brytpunkten passerats** — för tidig konvertering kostar K10-uppbyggnad och frivillig administration
+4. **Inte överväga 62-årsgyl** — pensionärer (även 62-åringar med hel pension) har drastiskt lägre egenavgifter i EF
+5. **Stoppa allt arbete vid 65** — fortsätt aktiv NV → utökat JSA, fortsatt pensionsintjäning
+6. **Glömma att EF-underskott från olika delverksamheter automatiskt kvittas** — ofta inte rimligt att sätta upp separata AB
+7. **Aktiekapital 25 000 kr som "lätt"** — i praktiken blir AB-ägare ofta personligt ansvariga via borgensavtal → personligt ansvar finns redan
+8. **Ansvarsgenombrott** — staten kan kräva betalning från AB-ägare för obetalda skatter/avgifter; ej helt riskfritt
+
+## Implementation checklist for software
+
+If you build software that helps users choose between EF and AB:
+
+- [ ] Ask: vinst-prognos per år nästa 3–5 år
+- [ ] Ask: ålder, pension-status
+- [ ] Ask: behöver begränsa personligt ansvar?
+- [ ] Ask: flera ägare? Make/sambo?
+- [ ] Ask: planerar sälja verksamheten framöver?
+- [ ] Ask: kulturarbetarverksamhet?
+- [ ] Ask: behöver SGI för planerad föräldraledighet?
+- [ ] Compute total effektiv skatt per year under EF-alt och under AB-alt med olika löne/utdelning-mixer
+- [ ] Surface "både och" som rekommendation om scenariot passar
+- [ ] Warn vid premature konvertering (under brytpunkten)
+- [ ] Warn att underskott i EF inte kan föras över till AB
+
+See also `swedish-tax-planning` (AB-specifik planering), [[aktiv-passiv-naringsverksamhet]] (gateway), [[periodiseringsfond-expansionsfond-ef]] (jämförelse med AB:s P-fond), [[rantefordelning-planning]] (motsvarighet till AB:s inlåning).

--- a/.claude/skills/swedish-ef-skatteplanering/references/egenavgifter-sgi-pgi-jsa.md
+++ b/.claude/skills/swedish-ef-skatteplanering/references/egenavgifter-sgi-pgi-jsa.md
@@ -1,0 +1,330 @@
+# Egenavgifter, SGI, PGI, Jobbskatteavdrag — Interaction Effects
+
+## Legal basis
+
+- Socialavgiftslagen (SAL) 2000:980 — egenavgifter
+- Lagen (1990:659) om särskild löneskatt på vissa förvärvsinkomster
+- IL 12 kap 37 § — jobbskatteavdrag (skattereduktion)
+- SFB (Socialförsäkringsbalken) 2010:110 — SGI, sjukpenning, föräldrapenning
+- IL 59 kap — pensionssparavdrag
+
+This reference covers the **interaction effects** between social charges, SGI, PGI, JSA and de skatteplanerings-instrument (P-fond, expansionsfond, räntefördelning, avskrivningar) som påverkar dessa underlag.
+
+## Egenavgifter — base rates
+
+### Standard rates (2025)
+
+| Group | Rate |
+|---|---|
+| Active näringsidkare, **7 karensdagar** (standard) | **28,97%** |
+| Active, 1 karensdag | ~29,2% (slightly higher) |
+| Active, 14 karensdagar | ~28,8% |
+| Active, 30 karensdagar | ~28,4% |
+| Active, 60 karensdagar | ~27,9% |
+| Active, 90 karensdagar | ~27,4% |
+| Passive näringsidkare (SLP) | **24,26%** |
+| Pensionär (≥ 65 vid årets ingång, eller hel pension hela året) | **10,21%** (bara ålderspensionsavgift) |
+| Född 1937 eller tidigare | **0%** |
+| Pensionär som är passiv | **24,26%** (SLP, ingen nedsättning till 10,21%) |
+
+### Karensval
+
+- Default: 7 karensdagar
+- Val of 1, 14, 30, 60 eller 90 karensdagar görs hos Försäkringskassan på blankett
+- Anmälan inom uppsägningstid: ny karens börjar gälla efter motsvarande antal dagar efter anmälan
+- Inte tillåtet att byta till kortare karens om man redan är inne i en sjukperiod
+- Försäkran krävs att inte ha någon pågående sjukdom (eller upplysa om den)
+
+PDF guidance:
+> "Vill du ändra antalet karensdagar ska du kontakta Försäkringskassan."
+
+### Ingen nedsättning för pensionärer eller +65
+
+Pensionärer (som redan betalar 10,21%) får **ingen** generell nedsättning. Likewise +62-åringar som tagit ut hel allmän pension hela året.
+
+### Regional nedsättning (stödområde A — Norrlands inland)
+
+10% extra nedsättning av avgiftsunderlaget upp till 180 000 kr → max 18 000 kr/year.
+
+Stödområdet = mest Norrlands inland. Lista finns hos Tillväxtverket.
+
+### Hel sjuk- eller aktivitetsersättning
+
+Helt eller delvis under året: bara ålderspensionsavgift (10,21%) på överskott av aktiv NV.
+
+## Generell nedsättning av egenavgifter — 7,5%
+
+PDF references describe this as "generell nedsättning":
+
+- **7,5 procentenheter** nedsättning av egenavgifter
+- Cap: max **15 000 kr/år** (= 7,5% av 200 000 kr underlag)
+- Underlag = överskott av **aktiv** NV (efter schablonavdrag för egenavgifter; exklusive sjukpenning)
+- Krav: överskottet **överstiger 40 000 kr** (= ca 50 000–52 000 kr i överskott före schablonavdrag)
+- Beräknas automatiskt av Skatteverket — du ska INTE begära den i deklarationen
+- Bara aktiva näringsidkare — ej för pensionärer (redan 10,21%) eller passiva (SLP utan nedsättning)
+
+### Marginalkurva i intervallet 40 001 – 200 000 kr
+
+In intervallet 40 001 – 200 000 kr underlag får du nedsättning på 5 procentenheter på **det belopp som överstiger 40 000 kr**. Wait — these numbers don't fully line up because the PDF references different reform versions. Verify with current SKV:
+
+PDF reference for the 5%-version:
+- 7,5% × (överskott − 40 000) upp till tak 15 000 kr
+- Innebär ~7,5% nedsättning gradvis upp till 200 000 kr underlag (full nedsättning vid 200 000)
+- Över 200 000 underlag = full nedsättning på endast den första 200 000 kr; resten utan nedsättning
+
+### Tröskeleffekt vid 40 000 kr
+
+PDF describes this märkliga effekt:
+> "Är överskottet 40 001 kr får du nedsättning på hela överskottet"
+> "Är överskottet bara 40 000 kr får du ingen nedsättning"
+
+So **omvänd marginalskatt** — going from 40 000 → 40 001 kr underlag triggers a sudden 3 000 kr nedsättning (7,5% × 40 000 = 3 000 kr).
+
+PDF: "Det är en ovanlig tröskeleffekt i skattesystemet, nämligen att en obetydlig höjning av inkomsten kan ge en så pass betydande skattesänkning."
+
+Software borde flagga overskott som ligger precis under 40 000 kr (warn att en kr över triggar bigger nedsättning).
+
+### Maxbelopp 200 000 kr (15 000 kr in nedsättning)
+
+Vid underlag 200 000 kr nås maxavdraget 15 000 kr. Über 200 000 är det ingen marginalfördel.
+
+## Schablonavdrag för egenavgifter på NE-bilaga
+
+- **R43**: avdrag för beräknade egenavgifter
+- **Max 25%** av överskott före schablonavdrag (aktiv standard)
+- **20%** för passiv (SLP)
+- **10%** för pensionärer
+- Tipsbart minska avdraget om man vill ha högre pensionsgrundande/sjukpenninggrundande inkomst
+- Tip från PDF: vid sista året före nedläggning, gör **exakt** schablonavdrag baklängesberäkning för att slippa avstämningspost nästa år
+
+### Avstämning nästa år
+
+Beräknat schablonavdrag stämmer aldrig exakt med faktiska egenavgifter. Differensen rättas till i nästa års deklaration:
+- **R39** = tidigare års schablonavdrag (läggs tillbaka som intäkt)
+- **R40** = faktiska egenavgifter / SLP enligt skattebeskedet (dras av)
+
+Net effect: schablonavdraget är ett genuint avdrag för året, men korrigeras nästa år mot verkligheten.
+
+### "Höja inkomsten" via lägre schablonavdrag
+
+PDF tip: ibland vill man höja den deklarerade inkomsten. Skäl:
+- Utnyttja rotavdrag / rutavdrag (kräver tillräckligt med skatt)
+- Höja PGI för pensionsrätt
+- Höja SGI (utan att Försäkringskassan adjusterar bort dispositioner — schablonavdraget är inte en disposition)
+
+Skatteverket kan vägra schablonavdragsändringar som verkar bedrägeriska — PDF: "Om det avsatta beloppet skiljer sig med så stort belopp att det kan antas att näringsidkaren försökt uppnå en obehörig förmån bör avdraget rättas."
+
+But: rimliga adjustments medges. Bara om man yrkar **noll** schablonavdrag eller mycket litet bör SKV granska.
+
+## Underlag för aktivitets-/sjukpenning (SGI)
+
+### Calculation
+
+SGI is computed by **Försäkringskassan** based on årsinkomst av arbete. För enskilda näringsidkare baseras SGI på:
+- Beräknad inkomst av aktiv NV
+- Bortser från **skattemässiga dispositioner**: avsättning/återföring av P-fond, expansionsfond
+- Bortser också från insättning/uttag på skogskonto, upphovsmannakonto
+- **Räntefördelning räknas** (men positiv minskar SGI eftersom NV-inkomsten minskar)
+- **Avskrivningar räknas** (höjda avskrivningar minskar SGI)
+- **Schablonavdrag för egenavgifter räknas** (men FK justerar — om du minskar schablonavdraget, FK ökar tillbaka motsvarande)
+
+### Tak och nedre gräns
+
+| Threshold | 2025 |
+|---|---|
+| Lägsta SGI (0,24 PBB) | 14 112 kr |
+| Lägsta för pensionsintjänande PGI (0,423 PBB) | 24 870 kr |
+| Max SGI (8 PBB) | 470 400 kr |
+| Max PGI (7,5 IBB) | 604 500 kr |
+| Max föräldrapenninggrundande (10 PBB) | 588 000 kr |
+| Max för 7,5%-nedsättning (200k underlag) | 200 000 kr |
+
+Sjukpenning = 77,6% (80% × 0,97) av SGI. Föräldrapenning likewise.
+
+### "Framåtriktad" SGI bedömning
+
+Försäkringskassan bedömer SGI **framåt** (vad antar de att näringsidkaren kommer tjäna nästa år), inte bakåt. Vid sjukdom:
+- För nystartade EF (inom första 24–36 månaderna, "uppbyggnadsskedet") jämförs med en motsvarande anställd inkomst
+- För etablerade EF: senaste års redovisade NV-inkomst används som proxy
+
+### Höjda SGI-strategies (om man har en känd kommande sjukdomsperiod / föräldraledighet)
+
+Saker som höjer SGI (men kostar i annan riktning):
+- Avstå från positiv räntefördelning → höjer NV-inkomsten
+- Avstå från eller minska avskrivningar på inventarier (de återkommer senare som mindre avskrivningar)
+- Mindre schablonavdrag för egenavgifter (FK skulle ofta justera, men inte alltid)
+- Negativ räntefördelning räknas full mot SGI (höjer den)
+
+OBS: P-fond avsättning/återföring påverkar INTE SGI (Försäkringskassan bortser).
+
+## Underlag för pensionsgrundande inkomst (PGI)
+
+### Differences from SGI
+
+PGI **påverkas** av:
+- Avsättning/återföring P-fond
+- Avsättning/återföring expansionsfond
+- Insättning/uttag skogskonto, upphovsmannakonto
+- Räntefördelning (positiv minskar, negativ höjer)
+- Avskrivningar
+- Schablonavdrag egenavgifter
+
+Praktisk skillnad: P-fond kan användas för PGI-utjämning (jämna ut PGI över åren), men INTE för SGI-utjämning.
+
+### Tak
+
+- Max: 7,5 inkomstbasbelopp ≈ **604 500 kr 2025** (verify)
+- Belopp över taket → ingen extra pension, men full egenavgift för aktiv NV
+- PDF kommentar: "den delen av socialavgifterna är en ren skatt och förs inte till pensionssystemet utan till statsbudgeten"
+
+### Lägsta gräns
+
+- 0,423 PBB ≈ 24 870 kr 2025
+- Om du når denna gränsen → full PGI från första kronan
+- Pension built varje krona under taket → strävan att alltid komma över 24 870 kr
+
+### Pensionärer (≥ 65 år)
+
+- Pensionärer betalar 10,21% egenavgifter på aktiv NV, but **får ändå full pensionsintjäning** (= the 10,21% is dedicated to ålderspensionsavgift, hela summan går till pension)
+- Hela livet räknas → man kan fortfarande bygga pensionspoäng efter pension
+- → starkt argument att fortsätta jobba aktivt efter 65
+
+## Jobbskatteavdrag (JSA) — skattereduktion för aktiva NV
+
+### Det är en skattereduktion, inte ett avdrag
+
+JSA är inte ett avdrag du gör i din deklaration. Det är en **skattereduktion** som beräknas automatiskt av Skatteverket → minskar din skatt.
+
+Underlag × kommunalskattesats = skattereduktion (jobbskatteavdrag).
+
+### Endast på inkomst av aktiv NV
+
+This is one of the largest specific incentives för aktiv-classification:
+
+- Pension, föräldrapenning, sjukpenning, a-kassa, sjuk-/aktivitetsersättning, livskaderänta → **ger inte rätt till JSA**
+- Anställningsinkomster → JA
+- Aktiv NV inkomst → JA
+- Passiv NV inkomst → NEJ
+
+### Beräkning (för personer under 65 år)
+
+| Inkomstskikt (arbetsinkomst) | Underlag (× kommunalskattesats) |
+|---|---|
+| ≤ 0,91 PBB | Arbetsinkomsten minus grundavdrag |
+| 0,91 – 3,24 PBB | 0,91 PBB + 34,05% av arbetsinkomst i detta skikt, minus grundavdrag |
+| 3,24 – 8,08 PBB | 1,703 PBB + 12,8% av arbetsinkomst i detta skikt, minus grundavdrag |
+| 8,08 – 13,54 PBB | 2,323 PBB minus grundavdrag |
+| > 13,54 PBB | 2,323 PBB minus grundavdrag, sedan reduceras med 3% av arbetsinkomster över 13,54 PBB |
+
+### Värden 2021 (illustrative, anchor for understanding)
+
+| Arbetsinkomst | Totalt JSA | % av inkomsten |
+|---|---|---|
+| 100 000 | 10 004 | 10,0% |
+| 200 000 | 17 442 | 8,7% |
+| 300 000 | 24 628 | 8,2% |
+| 400 000 | 30 252 | 7,6% |
+| 500 000 | 30 252 | 6,0% |
+| 600 000 | 30 252 | 5,0% |
+| 700 000 | 28 465 | 4,1% |
+| 900 000 | 22 466 | 2,5% |
+| 1 100 000 | 16 466 | 1,5% |
+
+Top JSA value: ~30 250 kr at inkomster 400 000 – 600 000 kr (= toppen av inkomst-skiktet 3,24 – 8,08 PBB).
+
+### Förhöjt JSA för +65-åringar
+
+Personer som vid årets ingång fyllt 65 år får utökat JSA:
+- 20% av arbetsinkomsten upp till 100 000 kr (= max 20 000 kr extra)
+- 5% av arbetsinkomster mellan 100 000 – 300 000 kr (= max 10 000 kr extra)
+- 30 000 kr på arbetsinkomster mellan 300 000 – 600 000 kr (= max 30 000 kr extra)
+- 30 000 kr på arbetsinkomster > 600 000 kr, minus 3% av arbetsinkomster över 600 000 kr
+
+Pensionärer som är aktiva i NV gets a *much* bigger JSA than under-65 människor, but only on aktiv arbetsinkomst (inte pensionen själv).
+
+### Arbetsinkomster — definition
+
+Arbetsinkomster = anställningsinkomster minskade med kostnader för inkomsterna i tjänst, samt allmänna avdrag (t.ex. pensionssparande), samt inkomst av **aktiv NV**.
+
+Inte räknas: pension, sjukpenning, föräldrapenning (även om dessa baseras på din aktiva NV).
+
+### Interaktion med allmänt avdrag (kvittning av underskott)
+
+Allmänt avdrag (kvittning av nystartad NV-underskott mot tjänst) **minskar** underlag för JSA. Net effekt:
+- Kvittning sparar marginalskatt + statlig skatt (~32–52%)
+- Men minskar JSA-reduktion → marginell motverkning
+
+This is why **rullning ofta är bättre än kvittning** — rullning minskar både egenavgifter och inkomstskatt på framtida intäkt, utan att äta JSA.
+
+## Interaktionsmatris — påverkan på underlag
+
+Quick reference för software:
+
+| Disposition | NV-inkomst | SGI | PGI | JSA-underlag | Egenavgifter | Egenavgifter-nedsättning |
+|---|---|---|---|---|---|---|
+| Positiv räntefördelning | Sänker | Sänker | Sänker | Sänker | Sänker | Underlag minskar → nedsättning minskar |
+| Negativ räntefördelning | Höjer | Höjer | Höjer | Höjer | Höjer | Underlag ökar |
+| P-fond avsättning | Sänker | INGEN (FK bortser) | Sänker | Sänker | Sänker | Underlag minskar |
+| P-fond återföring | Höjer | INGEN | Höjer | Höjer | Höjer | Underlag ökar |
+| Expansionsfond avsättning | Sänker | INGEN | Sänker | Sänker | Sänker (men 20,6% expansionsfondsskatt) | Underlag minskar |
+| Expansionsfond återföring | Höjer | INGEN | Höjer | Höjer | Höjer | Underlag ökar |
+| Avskrivningar (höjda) | Sänker | Sänker | Sänker | Sänker | Sänker | Underlag minskar |
+| Schablonavdrag (mindre) | Höjer | INGEN (FK adjusts back) | Höjer | Höjer | Höjer | Underlag ökar |
+| Pensionssparavdrag | Sänker | INGEN | Sänker | Sänker | Inget effekt direkt | Underlag minskar |
+| Allmänt avdrag (kvittning) | (utanför NV) | INGEN (FK adjusts) | Sänker (allmänna avdrag) | Sänker | INGEN (tjänsteinkomst) | INGEN |
+
+## Egenavgifter-effekt för aktiv vs passiv vs pensionär
+
+Comparing effective social charges:
+
+| Group | Direkt avgift | Generell nedsättning | Schablonavdrag | Effektiv avgift |
+|---|---|---|---|---|
+| Active, underlag 200 000 kr | 28,97% | -7,5% (max 15 000 kr) | 25% | ~21,5% effektivt |
+| Active, underlag 100 000 kr | 28,97% | -7,5% (15k cap progressive) | 25% | ~24,5% |
+| Passive, any underlag | 24,26% | 0% | 20% | ~24,26% |
+| Pensionär, aktiv | 10,21% | 0% | 10% | ~10,21% |
+| Pensionär, passiv | 24,26% | 0% | 20% | ~24,26% |
+
+Insight: A passive näringsidkare and an active näringsidkare may end up at similar effective rates (~24% each) due to nedsättning-effekten. But aktiv har **JSA on top** (~6–10% reduktion of marginalskatt at 200k income) → aktiv vinner generellt med 15–17 000 kr/år.
+
+## Underlag för nedre och övre PGI-gräns
+
+### Lägsta inkomstgräns (PBB-baserad)
+
+- 0,423 PBB = ca 24 870 kr 2025
+- Om du når detta → full PGI **från första kronan**
+- Strategy: ALWAYS get up to denna gränsen, even genom att lägre schablonavdrag for egenavgifter
+
+### Skattefri inkomst (för barn)
+
+- 20 135 kr (2021) = 0,423 PBB = same as lägsta PGI-gräns för "vanliga" arbetstagare och näringsidkare
+- Inkomst under denna gränsen behöver inte deklareras för fysiska personer (med vissa undantag) and är skattefri
+- Frestelse: hålla barnets lön precis under detta → skattefri inkomst
+- PDF: BÄTTRE att gå precis över → barnet får full pensionsintjäning (kostar 7% allmän pensionsavgift, men ger pension hela livet)
+
+## Pitfalls
+
+1. **Pensionärer som räntefördelar** — vanligen NEGATIVE planeringsutfall (PDF: "För +65-åringar är det bättre att låta bli räntefördelningen")
+2. **Förvirring av nedsättningar** — generell (7,5%, max 15k) ≠ regional (10%, max 18k) ≠ pensionär-rate (10,21% i stället för 28,97%)
+3. **P-fond för SGI-höjning** — fungerar INTE; Försäkringskassan bortser från P-fond
+4. **P-fond för PGI-höjning vid utbetalningsåret** — DOES work; FK does not adjust for P-fond when computing PGI
+5. **JSA-effekt av allmänt avdrag glömd** — kvittning sparar inkomstskatt men äter JSA → net effekt mindre än förväntat
+6. **Schablonavdrag för pensionärer** — bara 10% (inte 25%)
+7. **Schablonavdrag för SLP/passiv** — 20% (inte 25%)
+8. **Glömma att F-skatten redan inkluderar uppskattad egenavgift** — checkA-konto blir negativt om man **också** drar schablonavdrag mentalt utan att förstå att SKV redan beaktar
+9. **Tröskeleffekten vid 40 000 kr** — vinst 40 001 ger ~3 000 kr lägre skatt än 40 000 → uppmana till small overshoot om planeringsbart
+
+## Implementation checklist
+
+- [ ] Detect grupp: active under-65, active 65+, pensionär (tagit ut hel pension), passive
+- [ ] Apply rätt egenavgift-rate (28,97/24,26/10,21/0%)
+- [ ] Apply generell nedsättning 7,5% conditional on aktiv + > 40 000 underlag + cap 15 000 kr
+- [ ] Apply regional nedsättning if i stödområde A
+- [ ] Compute SGI based on aktiv NV-inkomst, ignoring P-fond/expansionsfond dispositions
+- [ ] Compute PGI including all dispositions
+- [ ] Compute JSA per skiktreglerna (under-65 vs 65+)
+- [ ] Warn vid underlag < 40 001 kr (lose nedsättning) eller < 24 870 kr (lose PGI)
+- [ ] Surface advice: "Höja inkomsten över 40 001 kr ger 3 000 kr lägre skatt; rekommendation: minska schablonavdrag eller P-fond avsättning"
+- [ ] Track per-year underlag history för SGI bedömning av FK (uppbyggnadsskede inom första 36 mån)
+
+See also [[aktiv-passiv-naringsverksamhet]] (the gateway to all of this), [[rantefordelning-planning]] (the most subtle interaction), [[periodiseringsfond-expansionsfond-ef]] (PGI-leveling tool), and [[ef-vs-ab-breakeven]] (interaction of these med AB-alternativet).

--- a/.claude/skills/swedish-ef-skatteplanering/references/egenavgifter-sgi-pgi-jsa.md
+++ b/.claude/skills/swedish-ef-skatteplanering/references/egenavgifter-sgi-pgi-jsa.md
@@ -4,7 +4,7 @@
 
 - Socialavgiftslagen (SAL) 2000:980 — egenavgifter
 - Lagen (1990:659) om särskild löneskatt på vissa förvärvsinkomster
-- IL 12 kap 37 § — jobbskatteavdrag (skattereduktion)
+- IL 67 kap 5-9 §§ — jobbskatteavdrag (skattereduktion)
 - SFB (Socialförsäkringsbalken) 2010:110 — SGI, sjukpenning, föräldrapenning
 - IL 59 kap — pensionssparavdrag
 
@@ -12,20 +12,33 @@ This reference covers the **interaction effects** between social charges, SGI, P
 
 ## Egenavgifter — base rates
 
-### Standard rates (2025)
+### Pensionärsåldersgränsen — höjs successivt
+
+Pensionärsstatus (10,21 % ålderspensionsavgift istället för full egenavgift) inträder året **efter** ett visst åldersfyllande. Gränsen följer den höjda pensionsåldersreformen:
+
+| Inkomstår | Full egenavgift t.o.m. året då man fyller | Pensionärsavgift fr.o.m. året då man fyller |
+|---|---|---|
+| 2022 och tidigare | 65 år | 66 år |
+| 2023 | 66 år | 67 år (höjning av riktåldern) |
+| 2025 | **66 år** | 67 år |
+| 2026 | **67 år** (höjning från 1 jan 2026) | 68 år |
+
+Äldre källor anger ofta 65 år som gräns — det är inaktuellt sedan riktåldern höjdes 2023, och vidare 2026. Verifiera mot Skatteverkets Belopp och procent för aktuellt år.
+
+### Standard rates (2025 och 2026, oförändrade procentsatser)
 
 | Group | Rate |
 |---|---|
-| Active näringsidkare, **7 karensdagar** (standard) | **28,97%** |
-| Active, 1 karensdag | ~29,2% (slightly higher) |
-| Active, 14 karensdagar | ~28,8% |
-| Active, 30 karensdagar | ~28,4% |
-| Active, 60 karensdagar | ~27,9% |
-| Active, 90 karensdagar | ~27,4% |
-| Passive näringsidkare (SLP) | **24,26%** |
-| Pensionär (≥ 65 vid årets ingång, eller hel pension hela året) | **10,21%** (bara ålderspensionsavgift) |
-| Född 1937 eller tidigare | **0%** |
-| Pensionär som är passiv | **24,26%** (SLP, ingen nedsättning till 10,21%) |
+| Active näringsidkare, **7 karensdagar** (standard) | **28,97 %** |
+| Active, 1 karensdag | ~29,2 % (slightly higher) |
+| Active, 14 karensdagar | ~28,8 % |
+| Active, 30 karensdagar | ~28,4 % |
+| Active, 60 karensdagar | ~27,9 % |
+| Active, 90 karensdagar | ~27,4 % |
+| Passive näringsidkare (SLP) | **24,26 %** |
+| Pensionär (året efter åldersgränsen, eller hel pension hela året) | **10,21 %** (bara ålderspensionsavgift) |
+| Född 1937 eller tidigare | **0 %** |
+| Pensionär som är passiv | **24,26 %** (SLP, ingen nedsättning till 10,21 %) |
 
 ### Karensval
 
@@ -34,9 +47,7 @@ This reference covers the **interaction effects** between social charges, SGI, P
 - Anmälan inom uppsägningstid: ny karens börjar gälla efter motsvarande antal dagar efter anmälan
 - Inte tillåtet att byta till kortare karens om man redan är inne i en sjukperiod
 - Försäkran krävs att inte ha någon pågående sjukdom (eller upplysa om den)
-
-PDF guidance:
-> "Vill du ändra antalet karensdagar ska du kontakta Försäkringskassan."
+- Karensvalet ändras hos Försäkringskassan, inte Skatteverket
 
 ### Ingen nedsättning för pensionärer eller +65
 
@@ -52,9 +63,9 @@ Stödområdet = mest Norrlands inland. Lista finns hos Tillväxtverket.
 
 Helt eller delvis under året: bara ålderspensionsavgift (10,21%) på överskott av aktiv NV.
 
-## Generell nedsättning av egenavgifter — 7,5%
+## Generell nedsättning av egenavgifter — 7,5 %
 
-PDF references describe this as "generell nedsättning":
+Skatteverket benämner detta "generell nedsättning":
 
 - **7,5 procentenheter** nedsättning av egenavgifter
 - Cap: max **15 000 kr/år** (= 7,5% av 200 000 kr underlag)
@@ -63,26 +74,27 @@ PDF references describe this as "generell nedsättning":
 - Beräknas automatiskt av Skatteverket — du ska INTE begära den i deklarationen
 - Bara aktiva näringsidkare — ej för pensionärer (redan 10,21%) eller passiva (SLP utan nedsättning)
 
-### Marginalkurva i intervallet 40 001 – 200 000 kr
+### Nedsättningens beräkning — KORREKT formel (Skatteverket)
 
-In intervallet 40 001 – 200 000 kr underlag får du nedsättning på 5 procentenheter på **det belopp som överstiger 40 000 kr**. Wait — these numbers don't fully line up because the PDF references different reform versions. Verify with current SKV:
+Nedsättningen beräknas som **7,5 % av hela avgiftsunderlaget**, dock max 15 000 kr/år. Förutsättning: full egenavgift betalas (28,97 %), aktiv NV och **överskottet överstiger 40 000 kr**.
 
-PDF reference for the 5%-version:
-- 7,5% × (överskott − 40 000) upp till tak 15 000 kr
-- Innebär ~7,5% nedsättning gradvis upp till 200 000 kr underlag (full nedsättning vid 200 000)
-- Över 200 000 underlag = full nedsättning på endast den första 200 000 kr; resten utan nedsättning
+```
+nedsättning = min(0,075 × underlag, 15 000)   när underlag > 40 000
+nedsättning = 0                                 när underlag ≤ 40 000
+```
+
+**Inget 40 000-belopp dras av från underlaget** — hela underlaget multipliceras med 7,5 %. Den formulering man ofta ser, `7,5 % × (överskott − 40 000)`, är felaktig — 40 000-gränsen är en *tröskel* för att nedsättningen ska utgå, inte ett avdragsbelopp.
+
+Exempel:
+- Underlag 100 000 kr → nedsättning = 0,075 × 100 000 = **7 500 kr**
+- Underlag 200 000 kr → nedsättning = 0,075 × 200 000 = **15 000 kr** (taket)
+- Underlag 300 000 kr → fortfarande max 15 000 kr (full nedsättning på de första 200 000, ingen marginalfördel över)
 
 ### Tröskeleffekt vid 40 000 kr
 
-PDF describes this märkliga effekt:
-> "Är överskottet 40 001 kr får du nedsättning på hela överskottet"
-> "Är överskottet bara 40 000 kr får du ingen nedsättning"
+Regeln ger en **omvänd marginalskatt** vid tröskeln. Underlag på 40 000 kr ger 0 i nedsättning; underlag på 40 001 kr ger nedsättning på hela underlaget (≈ 3 000 kr). En obetydlig höjning utlöser alltså en betydande skattesänkning.
 
-So **omvänd marginalskatt** — going from 40 000 → 40 001 kr underlag triggers a sudden 3 000 kr nedsättning (7,5% × 40 000 = 3 000 kr).
-
-PDF: "Det är en ovanlig tröskeleffekt i skattesystemet, nämligen att en obetydlig höjning av inkomsten kan ge en så pass betydande skattesänkning."
-
-Software borde flagga overskott som ligger precis under 40 000 kr (warn att en kr över triggar bigger nedsättning).
+Software bör flagga överskott precis under 40 000 kr — en krona över triggar nedsättningen.
 
 ### Maxbelopp 200 000 kr (15 000 kr in nedsättning)
 
@@ -95,7 +107,7 @@ Vid underlag 200 000 kr nås maxavdraget 15 000 kr. Über 200 000 är det ingen 
 - **20%** för passiv (SLP)
 - **10%** för pensionärer
 - Tipsbart minska avdraget om man vill ha högre pensionsgrundande/sjukpenninggrundande inkomst
-- Tip från PDF: vid sista året före nedläggning, gör **exakt** schablonavdrag baklängesberäkning för att slippa avstämningspost nästa år
+- Sista året före nedläggning: gör **exakt** schablonavdragsberäkning baklänges från beräknad faktisk egenavgift för att slippa en avstämningspost året därpå
 
 ### Avstämning nästa år
 
@@ -107,12 +119,12 @@ Net effect: schablonavdraget är ett genuint avdrag för året, men korrigeras n
 
 ### "Höja inkomsten" via lägre schablonavdrag
 
-PDF tip: ibland vill man höja den deklarerade inkomsten. Skäl:
-- Utnyttja rotavdrag / rutavdrag (kräver tillräckligt med skatt)
+Skäl att höja deklarerad inkomst genom att sänka schablonavdraget:
+- Utnyttja ROT/RUT-avdrag (kräver tillräckligt med skatt att reducera)
 - Höja PGI för pensionsrätt
-- Höja SGI (utan att Försäkringskassan adjusterar bort dispositioner — schablonavdraget är inte en disposition)
+- Höja SGI (Försäkringskassan justerar inte bort schablonavdrag — det är inte en disposition)
 
-Skatteverket kan vägra schablonavdragsändringar som verkar bedrägeriska — PDF: "Om det avsatta beloppet skiljer sig med så stort belopp att det kan antas att näringsidkaren försökt uppnå en obehörig förmån bör avdraget rättas."
+Skatteverket kan vägra schablonavdragsändringar som verkar bedrägeriska. Om det avsatta beloppet skiljer sig så markant att det kan antas att näringsidkaren försökt uppnå en obehörig förmån, kan avdraget rättas.
 
 But: rimliga adjustments medges. Bara om man yrkar **noll** schablonavdrag eller mycket litet bör SKV granska.
 
@@ -130,14 +142,19 @@ SGI is computed by **Försäkringskassan** based on årsinkomst av arbete. För 
 
 ### Tak och nedre gräns
 
-| Threshold | 2025 |
-|---|---|
-| Lägsta SGI (0,24 PBB) | 14 112 kr |
-| Lägsta för pensionsintjänande PGI (0,423 PBB) | 24 870 kr |
-| Max SGI (8 PBB) | 470 400 kr |
-| Max PGI (7,5 IBB) | 604 500 kr |
-| Max föräldrapenninggrundande (10 PBB) | 588 000 kr |
-| Max för 7,5%-nedsättning (200k underlag) | 200 000 kr |
+| Threshold | 2025 | 2026 |
+|---|---|---|
+| Prisbasbelopp (PBB) | 58 800 kr | 59 200 kr |
+| Förhöjt PBB | 60 000 kr | 60 500 kr |
+| Inkomstbasbelopp (IBB) | 80 600 kr | 83 400 kr |
+| Lägsta SGI (0,24 PBB) | 14 112 kr | 14 208 kr |
+| Lägsta för pensionsintjänande PGI (0,423 PBB) | 24 870 kr | 25 042 kr |
+| Max SGI (10 PBB) | 588 000 kr | 592 000 kr |
+| Max PGI (7,5 IBB) | 604 500 kr | 625 500 kr |
+| Avgiftstak (8,07 × IBB, pensionsgrundande tak) | 650 442 kr | 673 038 kr |
+| Max föräldrapenninggrundande (10 PBB) | 588 000 kr | 592 000 kr |
+| Max för 7,5 %-nedsättning egenavgifter (200k underlag) | 200 000 kr | 200 000 kr |
+| Halva PBB (förbrukningsinventarier-gräns) | 29 400 kr | 29 600 kr |
 
 Sjukpenning = 77,6% (80% × 0,97) av SGI. Föräldrapenning likewise.
 
@@ -173,9 +190,8 @@ Praktisk skillnad: P-fond kan användas för PGI-utjämning (jämna ut PGI över
 
 ### Tak
 
-- Max: 7,5 inkomstbasbelopp ≈ **604 500 kr 2025** (verify)
-- Belopp över taket → ingen extra pension, men full egenavgift för aktiv NV
-- PDF kommentar: "den delen av socialavgifterna är en ren skatt och förs inte till pensionssystemet utan till statsbudgeten"
+- Max: 7,5 inkomstbasbelopp ≈ **604 500 kr 2025**, **625 500 kr 2026**
+- Belopp över taket → ingen extra pension, men full egenavgift för aktiv NV. Den delen av socialavgifterna fungerar som ren skatt och förs inte till pensionssystemet utan till statsbudgeten.
 
 ### Lägsta gräns
 
@@ -216,31 +232,26 @@ This is one of the largest specific incentives för aktiv-classification:
 | 8,08 – 13,54 PBB | 2,323 PBB minus grundavdrag |
 | > 13,54 PBB | 2,323 PBB minus grundavdrag, sedan reduceras med 3% av arbetsinkomster över 13,54 PBB |
 
-### Värden 2021 (illustrative, anchor for understanding)
+### 2025/2026 förstärkningar — JSA har höjts varje budget sedan 2022
 
-| Arbetsinkomst | Totalt JSA | % av inkomsten |
-|---|---|---|
-| 100 000 | 10 004 | 10,0% |
-| 200 000 | 17 442 | 8,7% |
-| 300 000 | 24 628 | 8,2% |
-| 400 000 | 30 252 | 7,6% |
-| 500 000 | 30 252 | 6,0% |
-| 600 000 | 30 252 | 5,0% |
-| 700 000 | 28 465 | 4,1% |
-| 900 000 | 22 466 | 2,5% |
-| 1 100 000 | 16 466 | 1,5% |
+Äldre tabeller (≤ 2021) är inaktuella; JSA har förstärkts vid varje budgetproposition 2022–2026.
 
-Top JSA value: ~30 250 kr at inkomster 400 000 – 600 000 kr (= toppen av inkomst-skiktet 3,24 – 8,08 PBB).
+- **Inkomstår 2025**: max ~47 300 kr/år (≈ 3 941 kr/månad) för personer under pensionsåldersgränsen (66 år 2025).
+- **Inkomstår 2026** (prop. 2025/26:32 "Sänkt skatt på arbetsinkomster, pension och sjuk- och aktivitetsersättning"): max ~52 400 kr/år (≈ 4 366 kr/månad) för låg-/medelinkomsttagare med arbetsinkomst mellan ~191 800 och 478 300 kr/år (3,24–8,08 PBB).
+- Marginalskattesänkning för pensionärer höjs också 2026.
 
-### Förhöjt JSA för +65-åringar
+Använd alltid Skatteverkets aktuella jobbskatteavdragsräknare i implementationen — beloppen är dynamiska.
 
-Personer som vid årets ingång fyllt 65 år får utökat JSA:
-- 20% av arbetsinkomsten upp till 100 000 kr (= max 20 000 kr extra)
-- 5% av arbetsinkomster mellan 100 000 – 300 000 kr (= max 10 000 kr extra)
-- 30 000 kr på arbetsinkomster mellan 300 000 – 600 000 kr (= max 30 000 kr extra)
-- 30 000 kr på arbetsinkomster > 600 000 kr, minus 3% av arbetsinkomster över 600 000 kr
+### Förhöjt JSA för pensionärer (åldersgräns höjs successivt)
 
-Pensionärer som är aktiva i NV gets a *much* bigger JSA than under-65 människor, but only on aktiv arbetsinkomst (inte pensionen själv).
+Personer som vid årets ingång uppnått pensionsåldersgränsen (66 år 2025, **67 år 2026**) får utökat JSA. Strukturen nedan beskriver kalkylgrunden — exakta belopp justeras varje budget och bör hämtas från Skatteverket vid implementation:
+
+- 20 % av arbetsinkomsten upp till 100 000 kr (= max ~20 000 kr extra)
+- 5 % av arbetsinkomster mellan 100 000 – 300 000 kr (= max ~10 000 kr extra)
+- 30 000 kr på arbetsinkomster mellan 300 000 – 600 000 kr (= max ~30 000 kr extra)
+- 30 000 kr på arbetsinkomster > 600 000 kr, minus 3 % av arbetsinkomster över 600 000 kr
+
+Pensionärer som är aktiva i NV får ett **avsevärt större** JSA än under-pensionsåldersgränsen-personer, but only on aktiv arbetsinkomst (inte pensionen själv). Prop. 2025/26:32 förstärker även detta avdrag för 2026.
 
 ### Arbetsinkomster — definition
 
@@ -297,14 +308,14 @@ Insight: A passive näringsidkare and an active näringsidkare may end up at sim
 
 ### Skattefri inkomst (för barn)
 
-- 20 135 kr (2021) = 0,423 PBB = same as lägsta PGI-gräns för "vanliga" arbetstagare och näringsidkare
-- Inkomst under denna gränsen behöver inte deklareras för fysiska personer (med vissa undantag) and är skattefri
-- Frestelse: hålla barnets lön precis under detta → skattefri inkomst
-- PDF: BÄTTRE att gå precis över → barnet får full pensionsintjäning (kostar 7% allmän pensionsavgift, men ger pension hela livet)
+- 0,423 PBB = ca **24 870 kr (2025) / 25 042 kr (2026)** = samma som lägsta PGI-gräns
+- Inkomst under denna gräns behöver inte deklareras (med vissa undantag) och är skattefri
+- Frestelse: hålla barnets lön precis under → helt skattefri inkomst
+- **Bättre planeringsval**: gå precis över. Barnet får då full pensionsintjäning för året (kostar 7 % allmän pensionsavgift, men ger pension hela livet)
 
 ## Pitfalls
 
-1. **Pensionärer som räntefördelar** — vanligen NEGATIVE planeringsutfall (PDF: "För +65-åringar är det bättre att låta bli räntefördelningen")
+1. **Pensionärer som räntefördelar** — vanligen sämre netto-utfall. Pensionärsavgift (10,21 %) är redan lägre än räntefördelningens kapitalskatt (30 %), så ompostering till kapital blir oftast en förlust.
 2. **Förvirring av nedsättningar** — generell (7,5%, max 15k) ≠ regional (10%, max 18k) ≠ pensionär-rate (10,21% i stället för 28,97%)
 3. **P-fond för SGI-höjning** — fungerar INTE; Försäkringskassan bortser från P-fond
 4. **P-fond för PGI-höjning vid utbetalningsåret** — DOES work; FK does not adjust for P-fond when computing PGI

--- a/.claude/skills/swedish-ef-skatteplanering/references/ersattningsfond.md
+++ b/.claude/skills/swedish-ef-skatteplanering/references/ersattningsfond.md
@@ -1,0 +1,203 @@
+# Ersättningsfond (Replacement Reserve)
+
+## Legal basis
+
+- IL 31 kap (Ersättningsfond) — full chapter
+- IL 18 kap 15 § — interaction with inventarier
+- IL 31 kap 14–15 §§ — timeline rules
+
+## Purpose
+
+Ersättningsfond solves a tax-timing problem: you receive an **engångsersättning** (insurance, expropriation, statsbidrag) for an asset that has been or will be replaced. Without the fund, the ersättning is fully skattepliktig in the year it's received, while the avdrag (avskrivning, anskaffningsutgift) happens later when the replacement tillgång is bought — creating a brutal short-term skatt bill.
+
+Ersättningsfond **broggar beskattningsårets slutenhet** by allowing avsättning of the full ersättning in the same year, then later "tas i anspråk" mot anskaffningen av ersättningstillgången.
+
+## When ersättningsfond may be used (skadeersättning grunder)
+
+Avdrag för avsättning gets when näringsidkare gets ersättning for skada through:
+- Brand
+- Annan olyckshändelse (vatten, storm, blixt etc)
+- On inventarier, byggnader, markanläggningar, mark, eller djurlager
+- Ersättningen kan vara försäkringsersättning, statsbidrag, intrångsersättning, skadestånd
+
+Or for tvångsförsäljning / avyttring av näringsfastighet (del därav) genom:
+- Expropriation eller liknande
+- Tvångsavyttring vid sådana förhållanden att den annars inte skulle ha avyttrats
+- Avyttring för jordbrukets eller skogsbrukets yttre rationalisering
+- Avyttring till staten på grund av flygbuller
+- Inte kan brukas på grund av begränsning av förfoganderätten under obegränsad tid med stöd av miljöbalken eller naturvårdsföreskrifter
+
+(The miljö- och naturvård case covers naturvårdsområden / Natura 2000.)
+
+## Fyra ersättningsfonder
+
+The chapter recognizes **four separate fund types**, with different rules for vad de får tas i anspråk för:
+
+| Fund | For ersättning av | Får tas i anspråk för |
+|---|---|---|
+| Ersättningsfond för **inventarier** | Skada på inventarier | Avskrivning av nyköpta inventarier + utgifter för underhåll/reparation av inventarier; nedskrivning av djurlager |
+| Ersättningsfond för **byggnader och markanläggningar** | Skada eller tvångsavyttring av byggnad/markanläggning som är kapitaltillgång | Avskrivning + underhåll/reparation av byggnader/markanläggningar (kapitaltillgångar); ÄVEN avskrivning + underhåll/reparation av inventarier; ÄVEN nedskrivning av djurlager |
+| Ersättningsfond för **mark** | Skada eller tvångsavyttring av mark som är kapitaltillgång | Endast anskaffning av mark som är kapitaltillgång |
+| Ersättningsfond för **djurlager** | Skada på djurlager | Nedskrivning av djurlager (cap: max ersättningsutgifter for djuranskaffning under beskattningsåret) |
+
+Immateriella tillgångar (patent, mönsterskydd, mjölkkvoter, stödrätter) räknas INTE som inventarier för denna ersättningsfond.
+
+## Avdragets storlek
+
+You may avsätta a belopp **motsvarande den ersättning som tas upp i inkomstdeklarationen** (inte ersättningens fulla värde — bara den del som beskattas som NV-inkomst).
+
+For fastighet (kapitaltillgång): only the del of försäljningsvinsten som du redovisat som NV-inkomst (in stället för kapitalinkomst) blir basen. The seller can elect to lägga större del i NV för att kunna avsätta till ersättningsfond — det krävs så stor andel som motsvarar de tillgångar som ska användas i ersättningsfonden. Resterande kapitalvinst beskattas i inkomstslaget kapital.
+
+For mer än 30%-avskrivning under skadeåret eller om större underhåll skett, minskar avdraget i motsvarande mån.
+
+For vissa näringsidkare (såsom ålderspensionärer) där skatten på kapitalinkomst (30%) understiger marginalskatten på NV-inkomst, kan det löna sig att inte lägga in vinsten i NV-inkomstslaget och alltså avstå från ersättningsfond — RÅ 2010 ref 38.
+
+## När fonderna får tas i anspråk
+
+Tillgång eller arbete måste anskaffas / utföras **efter slutet av det beskattningsår** då avsättningen gjordes. Om man köper ersättningsinventarier under samma år som skadeåret, kan man INTE göra avsättning till ersättningsfond. Istället kan man använda 30-procentsregeln för avskrivning vilket innebär att försäkringsersättningen kvittas mot inköpet.
+
+Tip from PDF:
+> *"För att slippa omvägen över ersättningsfond, kan det löna sig att snabba på ersättningsinvesteringen, så att den hamnar på samma år som ersättningen."*
+
+Alt: try to time ersättningen i början av nästföljande år istället för i slutet av det innevarande, så att du har längre tid på dig.
+
+Fonden får också tas i anspråk för byggnader, markanläggningar och mark som anskaffas under **samma beskattningsår** som ersättningen ska tas upp som intäkt. I sådant fall ska det anses som om man gör en avsättning till fonden och att man tar fonden i anspråk omedelbart efteråt.
+
+If arbete på byggnader eller markanläggningar sträcker sig över flera beskattningsår, får fonden tas i anspråk under det sista beskattningsåret på tillgångarna eller utgifter för underhåll/reparationer av dem under de aktuella åren, om avdrag för utgifterna inte redan har gjorts de tidigare åren.
+
+## Turordning vid återföring
+
+A tidigare års avsättning anses ha tagits i anspråk **före en senare** avsättning till samma slags ersättningsfond (FIFO).
+
+## Beskattningskonsekvenser när fonderna tas i anspråk
+
+When ersättningsfond tas i anspråk:
+- Det ianspråktagna beloppet **tas EJ upp som intäkt**
+- Istället: utgiften som ersättningsfonden tas i anspråk för får inte dras av om utgiften annars skulle ha dragits av omedelbart
+
+For inventarier, byggnader, markanläggningar:
+- Räknas bara den del av tillgångarna' anskaffningsvärde *som inte täcks av det ianspråktagna beloppet* som anskaffningsvärde
+- Avskrivningar görs sedan på detta **nedräknade anskaffningsvärde**
+- Annars skulle beloppet få dras av två gånger
+
+For mark:
+- Anskaffningsutgiften för marken minskas med det ianspråktagna beloppet
+- Reduced anskaffningsutgift används vid framtida försäljning
+
+For lager:
+- Lagret anses nedskrivet med det ianspråktagna beloppet
+
+## Återföring efter tre år (om inte använd)
+
+Ersättningsfonden måste användas inom **tre år** från avsättningen. Annars måste fonden återföras till beskattning. Avdraget återförs i den inkomstdeklaration som lämnas för det tredje beskattningsåret efter det beskattningsår som avdraget gjordes.
+
+### Dispens vid svårigheter att hitta ersättningstillgångar
+
+Skatteverket kan medge dispens i ytterligare högst **tre år** om:
+- Sjukdom
+- Lågkonjunktur
+- Pandemi
+- Annat skäl
+
+Tip: pandemic exception was used during COVID-19 — verify exact wording for current SKV guidance.
+
+## Tvingande återföring (även om tiden inte gått ut)
+
+Avdraget ska återföras tidigare än 3-årsgränsen om:
+- Fonden tas i anspråk för annat än vad som är tillåtet
+- Den huvudsakliga delen av näringsverksamheten överlåts (såvida inte de nya ägarna övertar ersättningsfonderna — gäller inte vid expropriation och liknande)
+- Den huvudsakliga delen av NV övergår till en eller flera nya ägare på grund av arv, testamente eller bodelning. (Skatteverket kan medge att fonderna får tas över i sådant fall, gäller inte vid expropriation.)
+- Den som har fonden upphör att bedriva näringsverksamhet (gäller inte vid expropriation och liknande)
+- Den som har fonden försätts i konkurs
+
+If en ersättningsfond tas över anses den nye näringsidkaren själv ha gjort avsättningen och avdraget för denna det beskattningsår som avdraget faktiskt hör till.
+
+## Inkomstslag för återföringen
+
+Special rule for fastigheter avyttrade via expropriation:
+- Om en enskild näringsidkare har fått avdrag för avsättning till en ersättningsfond för **byggnader och markanläggningar** i samband med expropriation och liknande, ska återföringen göras i inkomstslaget **näringsverksamhet** med den del som motsvarar belopp som har tagits upp i NV.
+- Resten av avdraget ska återföras i inkomstslaget **kapital**. Återföringen beskattas alltså i samma inkomstslag som hade gällt om beskattningen skulle ha gjorts redan vid avyttringen.
+
+For ersättningsfond för **mark**, återföringen sker normalt i inkomstslaget **kapital**.
+
+## Tillägg vid återföring (3 år ut utan att tas i anspråk)
+
+When avdraget återförs (utan att fonden använts), ska ett **särskilt tillägg på 30%** av det återförda beloppet tas upp som intäkt. Detta för att avskräcka från att göra avsättningar bara för skattekredit.
+
+**This is the most important fact about ersättningsfond**: the 30% straffavgift makes ersättningsfond *unattractive* if you don't actually plan to invest in replacement assets. The PDF emphasizes:
+
+> *"Tillägget är så stort att det aldrig kan löna sig att avsätta till ersättningsfond enbart för att skjuta fram skatten."*
+
+Possibility of dispens for the timing exists, but the tillägget is mandatory.
+
+## Bokföringsmässig hantering
+
+Unlike P-fond and expansionsfond, **ersättningsfond skall bokföras**. The avsättning gör genom:
+
+```
+Debit  8xxx Avsättning till ersättningsfond  (resultatpåverkande)
+Credit 2060 Ersättningsfond                  (skuldsida balansräkning)
+```
+
+The avsättning to ersättningsfond skall bokföras via resultaträkningen för att vara avdragsgill. Detta är **motsatsen** till P-fond/expansionsfond för EF.
+
+OBS: en undantagsregel finns för **ersättningsfond för mark** — denna behöver inte bokföras enligt BFNAR 2006:1 (K1). Kontroll: läs BFNAR 2006:1 kommentar 9.2.
+
+In förenklat årsbokslut: redovisas via U3 (upplysning ersättningsfond) plus vanlig bokföring av avsättningen.
+
+BAS 2018 Förenklat årsbokslut: konto **2060 Ersättningsfond** — under eget kapital-rubriken, knuten till U3.
+
+## Worked example (from PDF)
+
+A näringsidkare gets försäkringsersättning of **1 000 000 kr** for a lastbil that burns up. Skattemässigt restvärde of the bilen was 0 (fully avskriven).
+
+### Scenario 1: Replace within same year
+Replace the lastbil with an identical truck for 1 000 000 kr (same year):
+- Skattemässig restvärde at year's end: 0 − 1 000 000 + 1 000 000 = 0
+- No skatt effect — försäkringsersättningen kvittas mot inköpet
+
+### Scenario 2: Replace next year (without ersättningsfond)
+- Försäkringsersättning 1 000 000 kr full intäkt skadeåret
+- Buy nytt for 1 000 000 kr next year → endast 300 000 kr avskrivning får göras (30% regeln på inventarier)
+- → Måste skatta för 1 000 000 kr **direkt** trots att alla pengar gått till ersättning
+
+### Scenario 3: Replace next year (with ersättningsfond)
+- Avsätt 1 000 000 kr till ersättningsfond för inventarier (avdrag = intäkten)
+- Skadeåret: net resultat 0
+- Nästa år: ta fonden i anspråk vid köp av nya lastbilen — anskaffningsvärdet räknas som 0 (efter ianspråktagande)
+- Future avskrivningar görs på 0 → inga avskrivningar
+- Net effect: matches scenario 1 — neutralt över tid
+
+## NE-bilaga reporting
+
+U-post **U3** i förenklat årsbokslut: ersättningsfond vid årets slut.
+
+Avsättning visas genom resultatpåverkan på resultatkontot (e.g., 8980 Återföring av ersättningsfond / 8990 Avsättning till ersättningsfond — branschspecifika BAS-koder).
+
+In NE: ersättningsfond hanteras genom de vanliga rutorna R5/R6 (kostnader) för avsättning och R1/R4 (intäkter) för återföring, plus särskilda justerings-poster vid återföring med 30% tillägg.
+
+## Common pitfalls
+
+1. **Avsättning till ersättningsfond utan replacement-plan** — 30% straffavgift om återförs utan ianspråktagande
+2. **Confusing inventarier/byggnad/mark/djurlager funds** — varje typ har olika ianspråk-regler; inventariefond får INTE användas för markköp
+3. **Anskaffning samma år som skadan** — då måste man använda 30-procentsregeln, inte ersättningsfond
+4. **Glömma att bokföra avsättningen** — för ersättningsfond ÄR det formellt samband (i motsats till P-fond EF)
+5. **3-årsgränsen** — Skatteverket återför automatiskt vid year 4 dispens-utan
+6. **Behandlar fastighetsavyttring som ren kapitalinkomst** — då blir det ingen NV-inkomst att avsätta från; måste medvetet lägga del i NV-inkomstslaget
+
+## Interaction with andra dispositions
+
+- Avsättning ersättningsfond minskar kapitalunderlaget för räntefördelning (skuldminskning)
+- Avsättning ersättningsfond minskar kapitalunderlaget för expansionsfond
+- Sparat fördelningsbelopp (positiv räntefördelning) kan användas mot återföring av ersättningsfond vid nedläggning av verksamheten
+
+## Out of scope
+
+Ersättningsfond is most relevant for:
+- Lantbruksföretag (djurlager, skog, mark)
+- Fastighetsförvaltning (expropriation)
+- Tunga maskiner i industri/transport
+
+For konsultverksamhet och kontorsbaserade EF är ersättningsfond sällan aktuell. Software targeting endast konsulter kan stänga av denna funktion.
+
+See also [[periodiseringsfond-expansionsfond-ef]] (the more commonly used reserveringsverktyg), and `swedish-asset-accounting` for general anläggningstillgångs-hantering.

--- a/.claude/skills/swedish-ef-skatteplanering/references/ersattningsfond.md
+++ b/.claude/skills/swedish-ef-skatteplanering/references/ersattningsfond.md
@@ -56,10 +56,9 @@ For vissa näringsidkare (såsom ålderspensionärer) där skatten på kapitalin
 
 Tillgång eller arbete måste anskaffas / utföras **efter slutet av det beskattningsår** då avsättningen gjordes. Om man köper ersättningsinventarier under samma år som skadeåret, kan man INTE göra avsättning till ersättningsfond. Istället kan man använda 30-procentsregeln för avskrivning vilket innebär att försäkringsersättningen kvittas mot inköpet.
 
-Tip from PDF:
-> *"För att slippa omvägen över ersättningsfond, kan det löna sig att snabba på ersättningsinvesteringen, så att den hamnar på samma år som ersättningen."*
+Optimering: snabba på ersättningsinvesteringen så att den hamnar på *samma år* som försäkringsersättningen — då kan 30 %-avskrivningsregeln för inventarier kvitta ut intäkten direkt, utan att gå omvägen via ersättningsfond.
 
-Alt: try to time ersättningen i början av nästföljande år istället för i slutet av det innevarande, så att du har längre tid på dig.
+Alt: tima försäkringsersättningen så att utbetalningen sker i början av nästföljande år istället för i slutet av innevarande → ger längre tid att finna ersättningstillgång inom samma beskattningsår.
 
 Fonden får också tas i anspråk för byggnader, markanläggningar och mark som anskaffas under **samma beskattningsår** som ersättningen ska tas upp som intäkt. I sådant fall ska det anses som om man gör en avsättning till fonden och att man tar fonden i anspråk omedelbart efteråt.
 
@@ -87,7 +86,9 @@ For mark:
 For lager:
 - Lagret anses nedskrivet med det ianspråktagna beloppet
 
-## Återföring efter tre år (om inte använd)
+## Återföring efter tre år (övergångsregel före 2026-04-01)
+
+För avsättningar gjorda **före 2026-04-01** gäller den äldre 3-årsregeln (se [10-årsregel-sektionen](#användningstid--förlängd-2026-3-år--10-år) för avsättningar gjorda från 2026-04-01).
 
 Ersättningsfonden måste användas inom **tre år** från avsättningen. Annars måste fonden återföras till beskattning. Avdraget återförs i den inkomstdeklaration som lämnas för det tredje beskattningsåret efter det beskattningsår som avdraget gjordes.
 
@@ -120,13 +121,19 @@ Special rule for fastigheter avyttrade via expropriation:
 
 For ersättningsfond för **mark**, återföringen sker normalt i inkomstslaget **kapital**.
 
-## Tillägg vid återföring (3 år ut utan att tas i anspråk)
+## Användningstid — förlängd 2026: 3 år → 10 år
 
-When avdraget återförs (utan att fonden använts), ska ett **särskilt tillägg på 30%** av det återförda beloppet tas upp som intäkt. Detta för att avskräcka från att göra avsättningar bara för skattekredit.
+**Skogsskattereformen 2026 (prop. 2025/26:69, ikraft 2026-04-01)** förlängde användningstiden från **3 år till 10 år**. Reformen är en del av en sammanhängande lantbruks-/skogsreform men gäller alla typer av ersättningsfond (inventarier, byggnader/mark, mark, djurlager) — inte bara skogsbruk.
 
-**This is the most important fact about ersättningsfond**: the 30% straffavgift makes ersättningsfond *unattractive* if you don't actually plan to invest in replacement assets. The PDF emphasizes:
+- **Avsättningar gjorda före 2026-04-01**: ursprungliga 3-årsregeln gäller (med möjlighet till dispens i ytterligare högst 3 år).
+- **Avsättningar gjorda fr.o.m. 2026-04-01**: 10-årsregeln gäller.
+- Övergångsregler för befintliga fonder — kontrollera mot Skatteverket vid behov.
 
-> *"Tillägget är så stort att det aldrig kan löna sig att avsätta till ersättningsfond enbart för att skjuta fram skatten."*
+## Tillägg vid återföring (om fonden inte tagits i anspråk inom användningstiden)
+
+When avdraget återförs (utan att fonden använts inom 3-/10-årstiden), ska ett **särskilt tillägg på 30 %** av det återförda beloppet tas upp som intäkt. Detta för att avskräcka från att göra avsättningar bara för skattekredit.
+
+**This is the most important fact about ersättningsfond**: the 30 % straffavgift makes ersättningsfond *unattractive* if you don't actually plan to invest in replacement assets. Tillägget är så pass tungt att det praktiskt taget aldrig lönar sig att göra avsättning enbart för att skjuta fram skatten — gör avsättningen bara om en konkret ersättningsinvestering är planerad inom användningstiden.
 
 Possibility of dispens for the timing exists, but the tillägget is mandatory.
 
@@ -147,26 +154,15 @@ In förenklat årsbokslut: redovisas via U3 (upplysning ersättningsfond) plus v
 
 BAS 2018 Förenklat årsbokslut: konto **2060 Ersättningsfond** — under eget kapital-rubriken, knuten till U3.
 
-## Worked example (from PDF)
+## Tre-scenario-jämförelse (illustrativ)
 
-A näringsidkare gets försäkringsersättning of **1 000 000 kr** for a lastbil that burns up. Skattemässigt restvärde of the bilen was 0 (fully avskriven).
+Setup: försäkringsersättning 1 000 000 kr för förstörd lastbil. Skattemässigt restvärde på bilen = 0 (helt avskriven).
 
-### Scenario 1: Replace within same year
-Replace the lastbil with an identical truck for 1 000 000 kr (same year):
-- Skattemässig restvärde at year's end: 0 − 1 000 000 + 1 000 000 = 0
-- No skatt effect — försäkringsersättningen kvittas mot inköpet
-
-### Scenario 2: Replace next year (without ersättningsfond)
-- Försäkringsersättning 1 000 000 kr full intäkt skadeåret
-- Buy nytt for 1 000 000 kr next year → endast 300 000 kr avskrivning får göras (30% regeln på inventarier)
-- → Måste skatta för 1 000 000 kr **direkt** trots att alla pengar gått till ersättning
-
-### Scenario 3: Replace next year (with ersättningsfond)
-- Avsätt 1 000 000 kr till ersättningsfond för inventarier (avdrag = intäkten)
-- Skadeåret: net resultat 0
-- Nästa år: ta fonden i anspråk vid köp av nya lastbilen — anskaffningsvärdet räknas som 0 (efter ianspråktagande)
-- Future avskrivningar görs på 0 → inga avskrivningar
-- Net effect: matches scenario 1 — neutralt över tid
+| Scenario | Skatteeffekt skadeåret | Skatteeffekt år 2 | Totalt över tid |
+|---|---|---|---|
+| **A: Ersätt samma år** (köp ny lastbil 1 000 000 kr) | Inkomst 1 000 000 + 30 %-regelns avskrivning på inköp 1 000 000 → netto 0 | Avskrivningsunderlag fortsatt 0 | **Neutralt** |
+| **B: Ersätt nästa år, INGEN ersättningsfond** | Intäkt 1 000 000 kr beskattas direkt; ingen kvittande kostnad | Köp 1 000 000 kr → 30 %-regelns avskrivning ger bara 300 000 kr avdrag år 2; resten avskrivs över ~3 år | **1 000 000 kr beskattas direkt utan kassaflöde** |
+| **C: Ersätt nästa år, MED ersättningsfond** | Avsätt 1 000 000 kr till fond → avdrag = intäkten → resultat 0 | Köp 1 000 000 kr; ta fond i anspråk → anskaffningsvärde räknas som 0 → inga framtida avskrivningar | **Neutralt över tid (matchar A)** |
 
 ## NE-bilaga reporting
 
@@ -182,7 +178,7 @@ In NE: ersättningsfond hanteras genom de vanliga rutorna R5/R6 (kostnader) för
 2. **Confusing inventarier/byggnad/mark/djurlager funds** — varje typ har olika ianspråk-regler; inventariefond får INTE användas för markköp
 3. **Anskaffning samma år som skadan** — då måste man använda 30-procentsregeln, inte ersättningsfond
 4. **Glömma att bokföra avsättningen** — för ersättningsfond ÄR det formellt samband (i motsats till P-fond EF)
-5. **3-årsgränsen** — Skatteverket återför automatiskt vid year 4 dispens-utan
+5. **Användningstidens slut** — 3 år för avsättningar före 2026-04-01, 10 år för avsättningar därefter. Skatteverket återför automatiskt vid år 4 (resp. år 11) utan dispens.
 6. **Behandlar fastighetsavyttring som ren kapitalinkomst** — då blir det ingen NV-inkomst att avsätta från; måste medvetet lägga del i NV-inkomstslaget
 
 ## Interaction with andra dispositions

--- a/.claude/skills/swedish-ef-skatteplanering/references/inkomstuppdelning-familj.md
+++ b/.claude/skills/swedish-ef-skatteplanering/references/inkomstuppdelning-familj.md
@@ -1,0 +1,199 @@
+# Inkomstuppdelning i Familjen
+
+## Legal basis
+
+- IL 60 kap (Inkomstuppdelning mellan makar och barn) — full chapter
+- IL 60 kap 2 § — lön till barn
+- IL 60 kap 6 § — F-skattegodkännande för medhjälpande make
+
+## Purpose
+
+In familjeföretag, det skattemässiga resultatet kan ofta delas mellan makar (eller mellan föräldrar och barn over 16 år). When properly motivated, this:
+- Reduces total skatt by moving inkomst from a high-skattesats person to a low-skattesats person
+- Builds **pensions- och sjukpenninggrundande inkomst** in the recipient
+- Crosses **brytpunkten för statlig skatt** to keep both makar under den
+
+The reglerna omfattar make/maka samt sambo med gemensamma barn (jämställd med make), och egna barn under och över 16 år (inkl. styvbarn och fosterbarn).
+
+## Two metoder: Medhjälparfallet vs Gemensam verksamhet
+
+### Medhjälparfallet (uneven roles)
+
+One make has a **ledande ställning** (företagsledande, with relevant utbildning/arbetsuppgifter), the other is medhjälpare.
+
+Test for ledande ställning:
+- Utbildning relevant för verksamheten?
+- Arbetsuppgifter som kräver expertkompetens?
+- Endast den ene har sådan kompetens → denne är företagsledare
+
+Worked example (PDF "Irena & Christer"):
+- Irena är läkare, driver läkarpraktik på deltid
+- Christer sköter bokföring och administration
+- Christer is medhjälpande make (saknar läkarexamen)
+- Om Christer själv utbildar sig till psykoterapeut → kan istället bli gemensam verksamhet
+
+#### Rules for medhjälparfallet
+
+The medhjälpande make may declare an inkomst from the verksamheten, **maximerat to marknadsmässig ersättning**:
+- 90 kr/timme + egenavgifter (= ca 118 kr/timme inkl egenavgifter) kan utan motivering anses marknadsmässig
+- Higher belopp kan motiveras med branscherfarenhet, utbildning eller kollektivavtal
+- Förmåner som den medhjälpande maken har får rymmas inom marknadsmässig ersättning
+
+Plus: medhjälpande maken may declare an **inkomst motsvarande rimlig ersättning på den kapitalinsats** som maken har gjort. The rimlig ersättning villkoret krävs att medhjälpande maken's kapitalunderlag för räntefördelning är >50 000 kr (annars går det inte att räntefördela).
+
+**INTE allowed**: fördelning av underskott till medhjälpande maken. Medhjälpande maken kan endast få ersättning om verksamheten gått med överskott.
+
+**INTE allowed**: F-skattegodkännande för medhjälpande maken (bara företagsledaren får detta).
+
+#### Aktiv/passiv classification i medhjälparfallet
+
+- Minst 500–600 arbetstimmar/år → medhjälpande maken's inkomst räknas som **aktiv** (gäller hela inkomsten, inkl räntan på kapital)
+- Under 500–600 timmar UTAN ägande: man tittar på om inkomsten är marknadsmässig ersättning för arbetsinsatsen → om så, aktiv
+- Under 500–600 timmar MED ägande: bedöms andelen av medhjälpande makens inkomst som hör till avkastning på kapital vs faktisk arbetsinsats
+- Om medhjälpande makens inkomst består **uteslutande av kapitalavkastning** → passiv för hela inkomsten
+
+### Gemensam verksamhet (equal roles)
+
+If båda makarna kan anses ha **samma ställning** i verksamheten, det är gemensam verksamhet:
+- Båda måste arbeta ungefär **lika mycket** (inte ledningskrav)
+- Inte nödvändigtvis lika andel av ägandet, men gärna
+- Typiskt: bondejordbruk, frisörsalong, butik där båda jobbar
+- **Inget krav på att båda har företagsledande ställning**
+
+#### Rules for gemensam verksamhet
+
+- Resultatet fördelas **efter arbetsinsatsen** (kan dras före schablonavdrag för egenavgifter, räntefördelning, periodiseringsfond, expansionsfond, JSA — eftersom dessa är personliga poster)
+- **Även underskott** får fördelas (i motsats till medhjälparfallet)
+- F-skattegodkännande: **båda** makarna kan få detta i gemensam verksamhet
+- Deklarationen: bara en av makarna behöver fylla i komplett NE-bilaga med alla siffror; andra maken fyller i grunduppgifter på NE + sista delen av NE-bilagan för sin andel
+- Räntefördelning, P-fond, expansionsfond beräknas personligt för varje make (egen kapitalunderlag)
+
+## Aktiv eller passiv för medhjälpande make
+
+| Make-pair situation | Klassificering |
+|---|---|
+| Båda makar aktivt arbetande (gemensam verksamhet) | Båda aktiva |
+| Båda makar mest medhjälpande/passiva | Båda passiva |
+| Företagsledande make aktiv, medhjälpande inte | Företagsledande maken aktiv; medhjälpande bedöms separat |
+| Medhjälpande maken jobbar ≥ 1/3 av heltid (500–600h) | Aktiv (smittar genom huvudsaklighetsregeln) |
+
+PDF guidance: "Det ligger då nära till hands att göra en likartad bedömning som för den företagsledande maken. Är den företagsledande maken aktiv, blir den medhjälpande maken också aktiv och vice versa."
+
+## Lön till barn
+
+### Barn under 16 år
+- Ersättningar och förmåner till **egna barn under 16 år** beskattas helt och hållet hos den make som deklarerar den **högsta inkomsten** från NV
+- Detta är en spärrregel — föräldrarna kan inte få en avdragsgill kostnad genom att betala barnet
+- Om makarna har lika stor inkomst, beskattas hos den **äldsta maken**
+
+### Barn som fyllt 16 år
+- Barn som fyllt 16 år kan **avlönas** och själv beskattas för beloppet
+- Övre gräns för marknadsmässig ersättning: **samma som för medhjälpande make** (90 kr/timme + egenavgifter)
+- Den del som överstiger marknadsmässig lön är *inte avdragsgill* för företaget, och inte heller arbetsgivaravgifter på överskjutande
+- Det finns **ingen övre åldersgräns** — gäller också vuxna barn
+- Det spelar ingen roll om barnet bor hemma
+- 16-årsdagen: arbetet ska *utföras efter* att barnet fyllt 16 år, men i praktiken utgår man från avlöningstillfället
+
+### Skatteplanering med barn 16+
+
+This is one of the largest single skattelättnader för en familjeföretagare med tonåringar.
+
+Worked example (PDF "Gabriel"):
+- Gabriel, 51, har EF med 800 000 kr överskott före schablonavdrag
+- Skatt + egenavgifter på 800 000 kr = **387 794 kr** (≈ 48,5%)
+- Gabriel netto: 800 000 − 354 094 (lön till skatt+egenavg) = 445 906 kr
+
+Nu introducerar en dotter, 17 år, som hjälper med hemsida och Facebook:
+- Lön till dottern 2 000 kr/månad = 24 000 kr/år (marknadsmässig)
+- Arbetsgivaravgifter 31,42% × 24 000 = 7 540 kr
+- Total kostnad i EF: 31 540 kr
+- Gabriels överskott sjunker till 800 000 − 31 540 = 768 460 kr
+- Skatt+egenavgifter på 768 460 = **334 931 kr**
+- Gabriel kvar: 433 729 kr
+
+Dottern har inga andra inkomster:
+- Lön 24 000 kr, skatt ~1 700 kr (grundavdrag äter upp), dottern kvar 22 300 kr
+
+**Sammanlagt familjen: 433 729 + 22 300 = 456 029 kr (mot 445 906 utan dottern)**
+
+Total skattelättnad: **10 123 kr**. Plus dottern bygger pensionsgrundande inkomst hela livet ut.
+
+PDF tips: höjning av dotterns lön så att hon kommer över **deklarationsgränsen 20 135 kr** (0,423 PBB) ger henne pensionsrätt från första kronan. Each krona over the deklarationsgränsen kostar 7% allmän pensionsavgift för dottern (≈ 1 400 kr för precis nå gränsen), men ger henne flera hundra kronor mer i pension varje år livet ut.
+
+### Beware skattefri inkomst frestelse
+
+Att hålla dotterns lön precis under deklarationsgränsen (20 135 kr) ger skattefri inkomst för barnet — but it's **dålig pensionsmässig planering**. Optimalt: precis över gränsen, så pensionsrätt utlöses.
+
+### Krav: faktiskt arbete
+
+För att avdraget ska godkännas måste barnet **verkligen ha utfört arbete** för företaget. Om det är ett fingerat avdrag (lön utan arbete) underkänns av Skatteverket och kan ge skattetillägg.
+
+## 7-årsregel (närstående)
+
+Vid övertagande av verksamhet från **närstående** within **5 år innan** företagsstarten:
+- The 5-årsregeln för kvittning av underskott i nystartad verksamhet gäller **endast om den närstående skulle ha fått kvitta** om han eller hon själv hade fortsatt att driva verksamheten
+- Övertagande från **förälder** eller **far-/morförälder** genom helt och hållet **köp** (inte gåva, arv eller testamente) räknas som **nystartad** verksamhet → 5-årsregeln gäller normalt
+
+Practical impact: arbeta som anställd hos en närstående i 5 år, ta över verksamheten genom köp → kvittningsregeln gäller på 5 nya år.
+
+## Andra än barn och makar
+
+### Enkelt bolag (konsortium)
+
+Flera enskilda näringsidkare kan samarbeta i ett **enkelt bolag**. Varje delägare deklarerar sin egen andel av intäkter och kostnader. Det enkla bolaget är inte ett skattesubjekt.
+
+Common between syskon som ägar lantbruk/näringsfastighet gemensamt, eller sambor (utan gemensamma barn) som driver verksamhet tillsammans (sambor utan gemensamma barn räknas **inte** som makar för skatteändamål → andra fördelningsregler).
+
+### F-skattegodkännande i enkelt bolag
+
+I gemensam verksamhet kan båda makarna anses som företagsledare och därmed kan **båda få godkännande för F-skatt**. Detta är en stor administrativ fördel jämfört med medhjälparfallet (där bara företagsledaren får F-skatt).
+
+## Räntefördelning + makar (key planning lever)
+
+In gemensam EF där makar tillsammans äger tillgångar och har skulder:
+- Each make computes kapitalunderlag på *sin andel* av tillgångar och skulder
+- Genom att fördela ägande av tillgångar och skulder kan en eller båda makar nå +50 001 räntefördelningsgräns
+
+Worked example (PDF, kvinnan + mannen verksamhet):
+- Maskin för 15 000 kr behöver köpas
+- Default: båda äger 50/50 → kvinnans kapitalunderlag 40k + 7,5k = 47,5k → fortfarande under 50k → ingen räntefördelning
+- Alt: låter kvinnan **köpa hela maskinen**: kvinnans kapitalunderlag 40k + 15k = 55k → räntefördelning på full 55k
+
+Such omflyttning ska göras civilrättsligt (faktiskt) — det räcker inte med en skriftlig fördelningsfiktion.
+
+## Pension and SGI through inkomstfördelning
+
+Inkomstfördelning between makar påverkar:
+- **Pensionsgrundande inkomst (PGI)**: 7,5 inkomstbasbelopp tak — om en make är över taket lägs överskottet i hennes inkomstslag onödigt; flytta över till den make som är under taket
+- **Sjukpenninggrundande inkomst (SGI)**: 8 prisbasbelopp tak — same logic
+- **Föräldrapenninggrundande inkomst**: 10 prisbasbelopp tak
+
+Tips:
+- **Make i karriär** (höginkomst, redan över taket): låt henne ta minimal andel av NV-inkomsten
+- **Make som ligger lågt** (deltidsanställd eller hemmamake): låt henne ta så stor andel att hon når lägsta inkomstgränsen för PGI (0,423 PBB ≈ 24 870 kr) → får pensionsrätt från första kronan
+
+## Pitfalls
+
+1. **Felaktig medhjälpar-/gemensam-klassificering** — Skatteverket kan omklassificera vid revision, vilket kan upphäva tidigare fördelningar
+2. **Underskott fördelat i medhjälparfallet** — INTE tillåtet; måste vara gemensam verksamhet
+3. **Lön till barn under 16 år** — INTE avdragsgillt; beskattas hos högsta make
+4. **Glömma marknadsmässig gräns för medhjälpande make / barn 16+** — överskridande ej avdragsgillt
+5. **Sambor utan gemensamma barn** — räknas EJ som makar; andra fördelningsregler (enkelt bolag)
+6. **F-skattegodkännande för medhjälpande make** — INTE tillåtet; bara företagsledare
+7. **Förmånsbeskattning av medhjälpande makens förmåner** — måste rymmas inom marknadsmässig ersättning
+8. **Stoppregel medhjälpande maken passiv när företagsledare aktiv** — ovanligt: brukar leda till samma klassificering. Software borde varna när detta upptäcks.
+
+## Implementation checklist for software
+
+If you build software for familjeägda EF:
+- [ ] Track *vilka makar* and *vilka barn* (med personnummer för F-skattekontroll)
+- [ ] Classify the arrangement: medhjälpar vs gemensam (UI question, persistera)
+- [ ] Validate that underskott not allocated to medhjälpande make
+- [ ] Enforce marknadsmässig ersättning cap (90 kr/h + egenavgifter) for medhjälpande make / barn
+- [ ] Track arbetstimmar per make per year (for aktiv/passiv)
+- [ ] Compute kapitalunderlag separately för each make (gemensam verksamhet)
+- [ ] Generate NE-bilaga primary + supplement layout
+- [ ] Flag the 16-årsdagen för barn som ska avlönas
+- [ ] Warn at the deklarationsgränsen 20 135 kr för barn (pension implications)
+
+See also [[aktiv-passiv-naringsverksamhet]], [[rantefordelning-planning]] (makar-fördelning av tillgångar), [[kvittning-underskott]] (närstående-takeover regel), and [[ackumulerad-inkomst]] (kan båda makar dra ackumulerad inkomst from gemensam verksamhet).

--- a/.claude/skills/swedish-ef-skatteplanering/references/inkomstuppdelning-familj.md
+++ b/.claude/skills/swedish-ef-skatteplanering/references/inkomstuppdelning-familj.md
@@ -26,11 +26,9 @@ Test for ledande ställning:
 - Arbetsuppgifter som kräver expertkompetens?
 - Endast den ene har sådan kompetens → denne är företagsledare
 
-Worked example (PDF "Irena & Christer"):
-- Irena är läkare, driver läkarpraktik på deltid
-- Christer sköter bokföring och administration
-- Christer is medhjälpande make (saknar läkarexamen)
-- Om Christer själv utbildar sig till psykoterapeut → kan istället bli gemensam verksamhet
+Räkneexempel: läkare driver praktik på deltid, andra maken sköter bokföring/administration.
+- Andra maken är **medhjälpande** (saknar läkarexamen → ingen ledande roll i kärnverksamheten)
+- Om andra maken själv utbildar sig till psykoterapeut → vägledande arbete inom kärnverksamheten → kan klassas som **gemensam verksamhet**
 
 #### Rules for medhjälparfallet
 
@@ -39,7 +37,7 @@ The medhjälpande make may declare an inkomst from the verksamheten, **maximerat
 - Higher belopp kan motiveras med branscherfarenhet, utbildning eller kollektivavtal
 - Förmåner som den medhjälpande maken har får rymmas inom marknadsmässig ersättning
 
-Plus: medhjälpande maken may declare an **inkomst motsvarande rimlig ersättning på den kapitalinsats** som maken har gjort. The rimlig ersättning villkoret krävs att medhjälpande maken's kapitalunderlag för räntefördelning är >50 000 kr (annars går det inte att räntefördela).
+Plus: medhjälpande maken may declare an **inkomst motsvarande rimlig ersättning på den kapitalinsats** som maken har gjort. Den rimliga ersättningen utgår från räntefördelningens kapitalunderlag — fr.o.m. inkomstår 2025 (prop. 2024/25:1) krävs inte längre att kapitalunderlaget överstiger 50 000 kr för att räntefördela. Räntefördelning får göras så snart kapitalunderlaget är positivt (≥ 0 kr).
 
 **INTE allowed**: fördelning av underskott till medhjälpande maken. Medhjälpande maken kan endast få ersättning om verksamheten gått med överskott.
 
@@ -77,7 +75,7 @@ If båda makarna kan anses ha **samma ställning** i verksamheten, det är gemen
 | Företagsledande make aktiv, medhjälpande inte | Företagsledande maken aktiv; medhjälpande bedöms separat |
 | Medhjälpande maken jobbar ≥ 1/3 av heltid (500–600h) | Aktiv (smittar genom huvudsaklighetsregeln) |
 
-PDF guidance: "Det ligger då nära till hands att göra en likartad bedömning som för den företagsledande maken. Är den företagsledande maken aktiv, blir den medhjälpande maken också aktiv och vice versa."
+Smittoeffekt: medhjälpande maken bedöms i regel på samma sätt som den företagsledande — om företagsledaren är aktiv blir medhjälparen i normalfallet också aktiv (och tvärtom).
 
 ## Lön till barn
 
@@ -98,31 +96,29 @@ PDF guidance: "Det ligger då nära till hands att göra en likartad bedömning 
 
 This is one of the largest single skattelättnader för en familjeföretagare med tonåringar.
 
-Worked example (PDF "Gabriel"):
-- Gabriel, 51, har EF med 800 000 kr överskott före schablonavdrag
-- Skatt + egenavgifter på 800 000 kr = **387 794 kr** (≈ 48,5%)
-- Gabriel netto: 800 000 − 354 094 (lön till skatt+egenavg) = 445 906 kr
+### Decision-mall: anställa barn 16+
 
-Nu introducerar en dotter, 17 år, som hjälper med hemsida och Facebook:
-- Lön till dottern 2 000 kr/månad = 24 000 kr/år (marknadsmässig)
-- Arbetsgivaravgifter 31,42% × 24 000 = 7 540 kr
-- Total kostnad i EF: 31 540 kr
-- Gabriels överskott sjunker till 800 000 − 31 540 = 768 460 kr
-- Skatt+egenavgifter på 768 460 = **334 931 kr**
-- Gabriel kvar: 433 729 kr
+Setup: aktiv EF, näringsidkare under brytpunkten, NV-överskott ~800 000 kr. Barn ≥ 16 utan andra inkomster anställs marknadsmässigt (t.ex. 24 000 kr/år för webbjobb).
 
-Dottern har inga andra inkomster:
-- Lön 24 000 kr, skatt ~1 700 kr (grundavdrag äter upp), dottern kvar 22 300 kr
+```
+1. Lönekostnad_barn = Bruttolön + AG-avgift (31,42 % × bruttolön)
+   Exempel: 24 000 + 7 540 = 31 540 kr/år
+2. EF_överskott_nytt = EF_överskott_före − Lönekostnad_barn
+3. Skatt_EF_efter = NV-marginalskatt × EF_överskott_nytt
+4. Skatt_barn = max(0, lön − grundavdrag) × kommunalskatt
+   Barn under grundavdraget: ~0 kr skatt → ren skatteförflyttning
+5. Familjebesparing = (Skatt_EF_före) − (Skatt_EF_efter + Skatt_barn)
+```
 
-**Sammanlagt familjen: 433 729 + 22 300 = 456 029 kr (mot 445 906 utan dottern)**
+Illustrativ effekt: vid 800 000 kr EF-överskott och 24 000 kr lön till barn (under grundavdraget) → familjebesparing ~10 000 kr/år. Plus barnet bygger PGI livet ut.
 
-Total skattelättnad: **10 123 kr**. Plus dottern bygger pensionsgrundande inkomst hela livet ut.
+Krav: barnet ≥ 16 år **vid avlöningstillfället**, faktiskt arbete utfört, marknadsmässig timlön (90 kr/tim + AG-avgift ofta godtagbart). Lön till barn under 16 är **inte avdragsgill** för EF.
 
-PDF tips: höjning av dotterns lön så att hon kommer över **deklarationsgränsen 20 135 kr** (0,423 PBB) ger henne pensionsrätt från första kronan. Each krona over the deklarationsgränsen kostar 7% allmän pensionsavgift för dottern (≈ 1 400 kr för precis nå gränsen), men ger henne flera hundra kronor mer i pension varje år livet ut.
+Planeringstips: höj barnets lön så att den hamnar precis över **deklarationsgränsen 0,423 × PBB** (=24 870 kr 2025 / 25 042 kr 2026) → utlöser pensionsrätt från första kronan. Varje krona över gränsen kostar 7 % allmän pensionsavgift för barnet, men ger flera hundra kronor mer i pension varje år livet ut.
 
-### Beware skattefri inkomst frestelse
+### Tröskeleffekt — skattefri inkomst vs PGI
 
-Att hålla dotterns lön precis under deklarationsgränsen (20 135 kr) ger skattefri inkomst för barnet — but it's **dålig pensionsmässig planering**. Optimalt: precis över gränsen, så pensionsrätt utlöses.
+Att hålla barnets lön precis *under* deklarationsgränsen ger skattefri inkomst men **ingen PGI**. Optimalt: precis *över* gränsen → liten direktkostnad mot stor pensionsvinst.
 
 ### Krav: faktiskt arbete
 
@@ -152,12 +148,15 @@ I gemensam verksamhet kan båda makarna anses som företagsledare och därmed ka
 
 In gemensam EF där makar tillsammans äger tillgångar och har skulder:
 - Each make computes kapitalunderlag på *sin andel* av tillgångar och skulder
-- Genom att fördela ägande av tillgångar och skulder kan en eller båda makar nå +50 001 räntefördelningsgräns
+- Genom att fördela ägande av tillgångar och skulder kan storleken av räntefördelningsbeloppet styras
 
-Worked example (PDF, kvinnan + mannen verksamhet):
+> **Notera (2025-reform):** Äldre källor talar om att nå "+50 001 räntefördelningsgräns" — den gränsen är **slopad fr.o.m. inkomstår 2025**. Numera går det att räntefördela från första positiva kronan, men storleken på kapitalunderlaget bestämmer fördelningsbeloppet (kapitalunderlag × SLR+6%). Större kapitalunderlag = större belopp som flyttas från NV till kapital (30 % skatt).
+
+Worked example (2025-regler):
 - Maskin för 15 000 kr behöver köpas
-- Default: båda äger 50/50 → kvinnans kapitalunderlag 40k + 7,5k = 47,5k → fortfarande under 50k → ingen räntefördelning
-- Alt: låter kvinnan **köpa hela maskinen**: kvinnans kapitalunderlag 40k + 15k = 55k → räntefördelning på full 55k
+- Default: båda äger 50/50 → kvinnans kapitalunderlag 40 000 + 7 500 = 47 500 kr → räntefördelningsbelopp 2025 = 47 500 × 7,96 % = 3 781 kr
+- Alt: låter kvinnan **köpa hela maskinen**: kvinnans kapitalunderlag 40 000 + 15 000 = 55 000 kr → räntefördelningsbelopp 2025 = 55 000 × 7,96 % = 4 378 kr
+- Skillnaden 597 kr × marginalskatte-besparing ≈ 100–200 kr/år för medel-EF; större värde vid större kapitalunderlag
 
 Such omflyttning ska göras civilrättsligt (faktiskt) — det räcker inte med en skriftlig fördelningsfiktion.
 
@@ -165,7 +164,7 @@ Such omflyttning ska göras civilrättsligt (faktiskt) — det räcker inte med 
 
 Inkomstfördelning between makar påverkar:
 - **Pensionsgrundande inkomst (PGI)**: 7,5 inkomstbasbelopp tak — om en make är över taket lägs överskottet i hennes inkomstslag onödigt; flytta över till den make som är under taket
-- **Sjukpenninggrundande inkomst (SGI)**: 8 prisbasbelopp tak — same logic
+- **Sjukpenninggrundande inkomst (SGI)**: **10 prisbasbelopp** tak (höjt från 7,5 PBB 2018; samma tak som föräldrapenning) — same logic
 - **Föräldrapenninggrundande inkomst**: 10 prisbasbelopp tak
 
 Tips:
@@ -194,6 +193,6 @@ If you build software for familjeägda EF:
 - [ ] Compute kapitalunderlag separately för each make (gemensam verksamhet)
 - [ ] Generate NE-bilaga primary + supplement layout
 - [ ] Flag the 16-årsdagen för barn som ska avlönas
-- [ ] Warn at the deklarationsgränsen 20 135 kr för barn (pension implications)
+- [ ] Warn at the deklarationsgränsen 0,423 × PBB (≈ 24 870 kr 2025 / 25 042 kr 2026) för barn (pension implications)
 
 See also [[aktiv-passiv-naringsverksamhet]], [[rantefordelning-planning]] (makar-fördelning av tillgångar), [[kvittning-underskott]] (närstående-takeover regel), and [[ackumulerad-inkomst]] (kan båda makar dra ackumulerad inkomst from gemensam verksamhet).

--- a/.claude/skills/swedish-ef-skatteplanering/references/kvittning-underskott.md
+++ b/.claude/skills/swedish-ef-skatteplanering/references/kvittning-underskott.md
@@ -51,29 +51,33 @@ Tekniskt: underskottet dras av som **allmänt avdrag** in INK1 sid 2 ruta **14.1
 
 Det allmänna avdraget minskar underlag för **jobbskatteavdrag** (subtle: less JSA om man kvittar). Det minskar också underlag för PGI och SGI (kvittning är intäktsneutral i den beräkningen — Försäkringskassan bortser från).
 
-### Worked example (PDF)
+### Worked example
 
-> *"Du har sammanlagda tjänsteinkomster på 280 000 kr. På det betalar du ca 61 000 kr i skatt. Men du har också en nystartad aktiv verksamhet som gett underskott på 50 000 kr."*
-> *"Du väljer att kvitta det underskottet mot dina tjänsteinkomster genom ett allmänt avdrag. Avdraget görs på baksidan av blankett INK1 (huvudblanketten), dit det förs från ruta R45 på bilaga NE."*
-> *"Effekten blir att du skattar på endast 280 000 – 50 000 = 230 000 kr. Det ger en skatt på ca 46 000 kr, dvs en minskad skatt på 61 000 – 46 000 = 15 000 kr."*
+Tjänsteinkomst 280 000 kr (skatt ca 61 000 kr) + nystartad aktiv EF med 50 000 kr underskott:
+- 50 000 kr förs från NE R45 till INK1 ruta 14.1 (allmänt avdrag)
+- Beskattningsbar tjänsteinkomst sänks till 230 000 kr → skatt ca 46 000 kr
+- Skatteminskning ≈ 15 000 kr
 
 ## Rullning bättre än kvittning ofta
 
-The PDF strongly emphasizes that **rullning is often better than kvittning** for näringsidkare who expect future profit:
-
-> *"För de näringsidkare som har underskott men som så småningom går med vinst, är rullningen mer gynnsam än kvittning mot tjänst. För det första får du då spara underskottet hur länge som helst. För det andra räknas underskottet av inte bara mot skatten, utan även mot egenavgifterna, vilket ger en högre avdragseffekt."*
+**Rullning är ofta bättre än kvittning** för näringsidkare som räknar med framtida vinst. Två skäl: (1) rullat underskott kan sparas obegränsat länge, (2) det räknas av mot både inkomstskatt *och* egenavgifter — högre avdragseffekt än kvittning mot tjänst, som bara minskar inkomstskatten.
 
 Rule of thumb: rullning ger **25–35 procentenheter bättre effekt** än kvittning mot tjänst (because kvittning bara sparar inkomstskatt; rullning sparar inkomstskatt + egenavgifter ~28,97%).
 
-PDF example:
-- År 1: konsultrörelse, underskott 40 000 kr (investeringar + marknadsföring)
-- Tjänsteinkomst år 1: 250 000 kr
-- Option A (kvittning): skatt minskar med ca 11 800 kr i år 1
-- Option B (rullning): inrullas till år 2
-- År 2: konsult vinst före egenavgifter 187 500 kr. Med inrullat underskott blir det 147 500 kr → skatt och egenavgifter ~46 000 kr (mot 63 200 utan inrullning)
-- Net rullningsförmån: 17 200 kr (vs kvittning's 11 800 kr) → **5 400 kr bättre med rullning**
+Räkneexempel (illustrativt):
+```
+år 1: underskott_NV = 40 000 kr, tjänsteinkomst = 250 000 kr
+  option_A (kvittning):  skattereduktion ≈ 11 800 kr i år 1     # bara inkomstskatt
+  option_B (rullning):   inrullas till år 2
 
-The catch: rullningen kräver att verksamheten faktiskt går med vinst senare. If verksamheten aldrig blir lönsam, kvittning är bättre.
+år 2: vinst_NV_före_egenavgifter = 187 500 kr
+  med inrullning: 187 500 − 40 000 = 147 500 kr → skatt+egenavgifter ≈ 46 000 kr
+  utan inrullning: skatt+egenavgifter ≈ 63 200 kr på 187 500 kr
+  rullningsförmån = 17 200 kr  (vs kvittning 11 800 kr)
+  → rullning ≈ 5 400 kr bättre
+```
+
+Villkor: rullning kräver att verksamheten faktiskt går med vinst senare. Om verksamheten aldrig blir lönsam → kvittning bättre (eller slutligt underskott vid avveckling, 70 %-regeln).
 
 ### Possibility för omprövning
 
@@ -84,7 +88,7 @@ Skatteverket allows ändring av val genom omprövning inom 5 år efter deklarati
 
 ## Kulturarbetare (special exemption)
 
-PDF reference: kulturarbetare = personer som uteslutande eller så gott som uteslutande sysslar med **konstnärlig, litterär eller liknande kulturell verksamhet**.
+Kulturarbetare = personer som uteslutande eller så gott som uteslutande sysslar med **konstnärlig, litterär eller liknande kulturell verksamhet**.
 
 Specials:
 - **Ingen 5-årsgräns** — kvittning får göras hur länge som helst
@@ -95,7 +99,7 @@ Specials:
 
 Skatteverket may dispens.
 
-PDF tips: "Om du har någon annan verksamhet vid sidan av kulturarbetarverksamheten, kan det i vissa fall löna sig att lägga den andra verksamheten i aktiebolag eller handelsbolag om du vill kunna utnyttja kulturarbetarkvittningen."
+Planeringstips: om man har annan verksamhet vid sidan av kulturarbetarverksamheten kan det vara värt att placera den andra verksamheten i AB eller HB — för att inte späda ut 90 %-kravet för kulturarbetarkvittningen i EF:n.
 
 ## Inrullning (rullning)
 
@@ -116,7 +120,7 @@ Rullningen kan göras under obegränsat antal år. Skatteverket kan ifrågasätt
 - Indikator för "ingen vinstsyfte" → hobbyverksamhet → näringsverksamhet kan avregistreras retroaktivt → underskottet återförs
 - För att visa vinstsyfte: redovisa **något** av intäkter (inte enbart kostnader)
 
-PDF tips: "Det bästa sättet att visa att du har vinstsyfte är att redovisa åtminstone några intäkter och inte enbart kostnader."
+Praktiskt: det bästa sättet att visa vinstsyfte är att redovisa **åtminstone några intäkter** varje år, inte enbart kostnader. Helt intäktslös verksamhet under lång tid är en stark indikator på hobbyverksamhet.
 
 ## Slutligt underskott vid avveckling
 
@@ -125,11 +129,11 @@ When verksamhet upphör helt (verksamheten avslutas, alla tillgångar säljs):
 ### Huvudregel
 
 Vid nedläggning av enskild näringsverksamhet:
-- 70% av slutligt underskott får utnyttjas som **kapitalförlust** i inkomstslaget kapital
-- Avdraget tas in i ruta **14.1 på baksidan av INK1**, året efter nedläggningsåret
-- Skattereduktion = 70% × 30% = **21%** skattereduktion på det kvarvarande underskottet
+- 70 % av slutligt underskott får utnyttjas som **kapitalförlust** i inkomstslaget kapital
+- Avdraget tas in i ruta **8.4 på INK1** ("Slutligt underskott av näringsverksamhet"), året efter nedläggningsåret. **Inte ruta 14.1** — 14.1 är allmänt avdrag för nystartad aktiv NV (de första 5 åren).
+- Skattereduktion = 70 % × 30 % = **21 %** skattereduktion på det kvarvarande underskottet
 
-Worked example (PDF):
+Worked example:
 - Slutligt underskott 80 000 kr vid nedläggning
 - Inkomstdeklaration året efter: 70% × 80 000 = 56 000 kr som kapitalförlust
 - Skatteminskning = 30% × 56 000 = **16 800 kr** (motsvarar 21% av 80k)
@@ -150,9 +154,7 @@ Om verksamheten ombildas till AB, kan underskottet **inte** föras över till AB
 - 70%-avdraget i kapital (om verksamheten faktiskt upphör)
 - ELLER om verksamheten *fortsätter parallellt* i AB och EF, finns ingen formell upphörande → underskottet rullas vidare i EF
 
-PDF restriction: "Möjligheterna till avdrag för slutligt underskott är dock begränsade vid en ombildning till ett aktiebolag eftersom tillgångarna förs ut ur den enskilda firman till underpris och det inte blivit någon uttagsbeskattning."
-
-This restriction prevents using a sham ombildning + nedläggning to convert future-rolling underskott into immediate kapitalförlust.
+Spärr vid ombildning till AB: tillgångarna förs ut ur den enskilda firman till underpris utan uttagsbeskattning, varför avdrag för slutligt underskott är begränsat. Detta blockerar konstruktionen "sham ombildning + nedläggning" som annars hade kunnat konvertera framtida rullbart underskott till omedelbar kapitalförlust.
 
 ## Dödsbon
 
@@ -161,23 +163,30 @@ Same regler:
 - Dödsboet kan ta över ansvar för kvarvarande underskott
 - Vid bouppteckning: om endast en dödsbodelägare → dödsboet anses skiftat redan vid bouppteckning → underskottet förloras
 - Vid flera dödsbodelägare → dödsboet kan leva vidare och utnyttja underskottet
-- Tip from PDF: vid risk för att underskott försvinner, gör **partiellt arvsavstående** för att skapa flera dödsbodelägare
+- Mitigation: vid risk för att underskott försvinner, gör **partiellt arvsavstående** för att skapa flera dödsbodelägare
 
 ## Kvittning vid övergång passiv → aktiv
 
-PDF specific case: Christer har hyreshus (passiv) med underskott rullande.
+Exempel:
+```
+år 1: hyreshus (passiv), underskott 80 000 kr → rullas framåt (passiv ger ingen kvittning mot tjänst)
+år 2: ytterligare 50 000 kr underskott → ackumulerat rullande 130 000 kr
+år 3: ägaren slutar sin anställning, börjar arbeta ≥ 500 h/år i verksamheten → klassificering passiv → aktiv
+       överskott 40 000 kr
+       inrullat underskott (rullas från passiv-perioden) får kvittas mot årets aktiv-överskott → netto 0
+       återstående rullande underskott = 130 000 − 40 000 = 90 000 kr
+```
 
-År 1: hyreshus, underskott 80 000 kr → rullas framåt (passiv → ingen kvittning mot tjänst)
-År 2: tillkommer ytterligare 50 000 kr underskott → rullas framåt → ackumulerat 130 000 kr
-År 3: Christer slutar sin anställning, skaffar nya fastighet och börjar arbeta i verksamheten ≥ 500 h/år → klassificeras som **aktiv**. Överskott 40 000 kr.
+Effekt: hela ackumulerade underskottet (130 000 kr) kan dras av (vanlig rullning), men dessutom kan resterande 90 000 kr av nettounderskottet **kvittas mot tjänst** med allmänt avdrag — eftersom verksamheten är aktiv i bedömningsåret. Att verksamheten varit passiv under tidigare år påverkar inte rätten det aktuella året.
 
-Effekt: hela ackumulerade underskottet (130 000 kr) kan dras av (vanlig rullning), men dessutom kan resterande 90 000 kr av nettounderskottet (130 000 − 40 000 = 90 000) **kvittas mot tjänst** med allmänt avdrag — eftersom verksamheten är aktiv i bedömningsåret. PDF: "Att verksamheten har varit passiv under de föregående åren har ingen betydelse."
+### 5-årsgränsens räknepunkt
 
-### 5-årsgränsen — but Christer is past 5 years
+Det krävs aktiv NV. 5-årsgränsen för nystartad ska gälla *från företagsstarten*:
+- Verksamheten startade aktivt → 5 år börjar då
+- Verksamheten startade passivt och blev sen aktiv → oklart om 5 år räknas från start eller från övergång till aktiv
+- Skatteverkets ställningstagande **dnr 131 657367-11/111** ger viss vägledning — verifiera exakt tolkning vid implementation
 
-Det krävs aktiv NV. The 5-årsgränsen från nystartad ska gälla *från företagsstarten*. Om verksamheten startade aktivt → 5 år börjar då. Om verksamheten startade passivt och senare blir aktiv, är det oklart om 5 år räknas från start eller från övergång till aktiv. Skatteverkets ställningstagande (131 657367-11/111) ger guidance — verify exact tolkning.
-
-PDF case suggests: kvittning är möjlig så länge verksamheten är aktiv under bedömningsåret. But proceed with caution.
+Praktisk princip: kvittning är möjlig så länge verksamheten är aktiv under bedömningsåret, men närma fallet med försiktighet vid passiv→aktiv-övergångar nära 5-årsgränsen.
 
 ## Komplettering med ny verksamhet
 
@@ -203,11 +212,23 @@ Inom EF: alla delverksamheter slås automatiskt ihop till **en enda näringsverk
 
 **Implication**: starting a profitable verksamhet samtidigt som man har en förlustverksamhet i samma EF → vinsten quenchas av förlusten utan ny ansökan eller särskild bokföring.
 
-PDF example: Bertil har AB med 520 000 kr vinst (skattas högt). Plus EF (hyreshus) med 100 000 kr förlust per år.
-- Option A: Behåll AB+EF → vinsten beskattas i AB, förlusten rullas i EF. Bertil får 299 000 kr efter skatt från AB-vinsten, plus 100 000 kr cash tillgängliga utan beskattning (eftersom EF-förlusten finansieras av AB-pengar via uttag).
-- Option B: skrota AB:et, lägg konsultverksamheten i EF:en med hyreshuset → sammanlagd vinst 420 000 kr → skatt+egenavg ~166 976 kr → **253 024 kr kvar** vs option A's 199 000 kr. Save 54 024 kr.
+Räkneexempel (illustrativt): AB med 520 000 kr vinst (full bolagsskatt + utdelnings-/lönebeskattning) + separat EF med hyresfastighet (100 000 kr underskott per år).
 
-This is the **biggest single argument for EF over AB** for low-to-mid income with concurrent förlustverksamhet.
+```
+option_A: behåll AB+EF separat
+  AB-vinst beskattas i AB; EF-underskott rullas (kan inte kvittas mot AB-vinst)
+  efter skatt på AB-vinst ≈ 299 000 kr
+
+option_B: avveckla AB, slå ihop verksamheten i EF
+  sammanlagt EF-resultat = AB-konsult-vinst − hyresfastighetens underskott
+                         = 520 000 − 100 000 = 420 000 kr
+  EF-skatt + egenavgifter på 420 000 ≈ 166 976 kr
+  → 253 024 kr kvar
+
+besparing ≈ 54 000 kr/år genom intern kvittning i EF
+```
+
+Detta är det **enskilt största argumentet för EF över AB** vid kombinerad förlust- och vinstverksamhet i samma hushåll.
 
 ## NE-bilaga / INK1 rutor
 
@@ -218,7 +239,7 @@ This is the **biggest single argument for EF over AB** for low-to-mid income wit
 | NE R47/R48 | Överskott / underskott av aktiv NV |
 | NE R49/R50 | Överskott / underskott av passiv NV |
 | INK1 14.1 | Allmänt avdrag för underskott i nystartad aktiv NV (sidan 2 baksida) |
-| INK1 14.1 (slutligt) | 70% av slutligt underskott i avslutad EF, året efter nedläggning |
+| INK1 8.4 | 70 % av slutligt underskott i avslutad EF, året efter nedläggning ("Slutligt underskott av näringsverksamhet") |
 
 ## Pitfalls
 

--- a/.claude/skills/swedish-ef-skatteplanering/references/kvittning-underskott.md
+++ b/.claude/skills/swedish-ef-skatteplanering/references/kvittning-underskott.md
@@ -1,0 +1,245 @@
+# Kvittning av Underskott i Enskild Firma
+
+## Legal basis
+
+- IL 62 kap 2–3 §§ — Allmänna avdrag, underskott av aktiv nystartad NV
+- IL 42 kap 33–34 §§ — Slutligt underskott vid avveckling
+- IL 14 kap 21–22 §§ — Rullning av underskott inom NV
+- Skatteverket dnr 131 657367-11/111 — Allmänt avdrag för underskott av nystartad verksamhet
+
+## Three modes of dealing with underskott
+
+An EF underskott (negative inkomst av näringsverksamhet) can be handled in three ways:
+
+1. **Rullning framåt** — quietly carry forward into the same näringsverksamhet, kvitta mot framtida överskott
+2. **Kvittning mot andra förvärvsinkomster** — allmänt avdrag in INK1 R14.1, kvittas mot lön/pension/handelsbolagsinkomst
+3. **Slutligt underskott** vid avveckling — 70% av kvarvarande underskott blir kapitalförlust som dras av i kapital
+
+These are mutually exclusive for the same kronor.
+
+## Förutsättningar för kvittning mot andra förvärvsinkomster
+
+Allmänt avdrag enligt IL 62 kap 3 § kräver ALLT av följande:
+
+1. **Aktivt bedriven** näringsverksamhet (passiv → ingen kvittning mot tjänst, bara rullning)
+2. **Nystartad** verksamhet — *de första 5 åren*
+3. **Inte direkt eller indirekt bedrivit likartad verksamhet** under de senaste 5 åren innan starten (anti-omklassificering-skydd)
+4. **Cap: 100 000 kr/år** för vart och ett av de fem åren
+
+Verksamhet startad 2025 → kvittning får göras i deklarationer 2026, 2027, 2028, 2029 och 2030 (för beskattningsåren 2025-2029, dvs år 1-5).
+
+### Vad "likartad verksamhet under 5 år" betyder
+
+Du får inte ha drivit samma typ av verksamhet (i AB, HB, EF, eller som anställd entreprenör) under 5 år innan starten. Detta utesluter:
+- Restart of a dissolved EF under same name
+- Spin-out from an AB you previously owned
+- Move from anställning som konsult to konsult-EF in samma bransch (yes, this often catches consultants)
+
+Skatteverket may dispens om verksamheten är genuint ny i meningfull sense.
+
+### Cap 100 000 kr per år
+
+Each av de 5 åren får kvitta upp till 100 000 kr — så total max över 5 år är 500 000 kr som allmänt avdrag.
+
+Underskott som överstiger 100 000 kr ett enskilt år kan:
+- Rullas framåt i NV (mot framtida överskott)
+- ELLER kvittas ett senare år (om det blir ny förlust under perioden)
+
+### Allmänt avdrag mekanik
+
+Tekniskt: underskottet dras av som **allmänt avdrag** in INK1 sid 2 ruta **14.1**. Avdraget görs från R45 på NE.
+
+Det allmänna avdraget minskar underlag för **jobbskatteavdrag** (subtle: less JSA om man kvittar). Det minskar också underlag för PGI och SGI (kvittning är intäktsneutral i den beräkningen — Försäkringskassan bortser från).
+
+### Worked example (PDF)
+
+> *"Du har sammanlagda tjänsteinkomster på 280 000 kr. På det betalar du ca 61 000 kr i skatt. Men du har också en nystartad aktiv verksamhet som gett underskott på 50 000 kr."*
+> *"Du väljer att kvitta det underskottet mot dina tjänsteinkomster genom ett allmänt avdrag. Avdraget görs på baksidan av blankett INK1 (huvudblanketten), dit det förs från ruta R45 på bilaga NE."*
+> *"Effekten blir att du skattar på endast 280 000 – 50 000 = 230 000 kr. Det ger en skatt på ca 46 000 kr, dvs en minskad skatt på 61 000 – 46 000 = 15 000 kr."*
+
+## Rullning bättre än kvittning ofta
+
+The PDF strongly emphasizes that **rullning is often better than kvittning** for näringsidkare who expect future profit:
+
+> *"För de näringsidkare som har underskott men som så småningom går med vinst, är rullningen mer gynnsam än kvittning mot tjänst. För det första får du då spara underskottet hur länge som helst. För det andra räknas underskottet av inte bara mot skatten, utan även mot egenavgifterna, vilket ger en högre avdragseffekt."*
+
+Rule of thumb: rullning ger **25–35 procentenheter bättre effekt** än kvittning mot tjänst (because kvittning bara sparar inkomstskatt; rullning sparar inkomstskatt + egenavgifter ~28,97%).
+
+PDF example:
+- År 1: konsultrörelse, underskott 40 000 kr (investeringar + marknadsföring)
+- Tjänsteinkomst år 1: 250 000 kr
+- Option A (kvittning): skatt minskar med ca 11 800 kr i år 1
+- Option B (rullning): inrullas till år 2
+- År 2: konsult vinst före egenavgifter 187 500 kr. Med inrullat underskott blir det 147 500 kr → skatt och egenavgifter ~46 000 kr (mot 63 200 utan inrullning)
+- Net rullningsförmån: 17 200 kr (vs kvittning's 11 800 kr) → **5 400 kr bättre med rullning**
+
+The catch: rullningen kräver att verksamheten faktiskt går med vinst senare. If verksamheten aldrig blir lönsam, kvittning är bättre.
+
+### Possibility för omprövning
+
+Skatteverket allows ändring av val genom omprövning inom 5 år efter deklarationsåret. So:
+- År 1: gör allmänt avdrag (kvitta mot tjänst), spara ingen rullning
+- Senare upptäcker att verksamheten gick med vinst → begär omprövning av år 1 → ändra valet till rullning → börja om
+- Var medveten: omprövning kan utlösa **kostnadsränta** på det belopp där skatten egentligen var högre
+
+## Kulturarbetare (special exemption)
+
+PDF reference: kulturarbetare = personer som uteslutande eller så gott som uteslutande sysslar med **konstnärlig, litterär eller liknande kulturell verksamhet**.
+
+Specials:
+- **Ingen 5-årsgräns** — kvittning får göras hur länge som helst
+- **Inget årligt tak på 100 000 kr** — fri kvittning
+- Cap: avdrag bara för **årets underskott** (kvarvarande underskott från tidigare år får inte dras som allmänt avdrag)
+- "Uteslutande eller så gott som uteslutande" = ca 90–95% av verksamheten ska vara kulturarbetarverksamhet
+- Krav: intäkter under en period som omfattar beskattningsåret och de tre föregående beskattningsåren får inte vara obetydliga (≈ minst ett halvt inkomstbasbelopp/år i genomsnitt; ≈ 34 100 kr 2021)
+
+Skatteverket may dispens.
+
+PDF tips: "Om du har någon annan verksamhet vid sidan av kulturarbetarverksamheten, kan det i vissa fall löna sig att lägga den andra verksamheten i aktiebolag eller handelsbolag om du vill kunna utnyttja kulturarbetarkvittningen."
+
+## Inrullning (rullning)
+
+Rullning is the **default** treatment for underskott of:
+- Passiv NV (no kvittning mot tjänst available)
+- Aktiv NV efter 5-årsgränsen
+- Aktiv NV där 100k cap är fyllt
+- Slutligt underskott (om verksamhet inte upphör)
+
+Mechanics:
+- Underskottet rullas in i nästa års NE-bilaga ruta R24
+- Minskar resultatet i nästa år
+- Räknas mot egenavgifter, inkomstskatt och statlig skatt → **högre avdragseffekt** än kvittning mot tjänst
+
+### Ingen tidsbegränsning
+
+Rullningen kan göras under obegränsat antal år. Skatteverket kan ifrågasätta att näringsidkaren har **vinstsyfte** om regelmässigt stora underskott uppkommer under en lång tid:
+- Indikator för "ingen vinstsyfte" → hobbyverksamhet → näringsverksamhet kan avregistreras retroaktivt → underskottet återförs
+- För att visa vinstsyfte: redovisa **något** av intäkter (inte enbart kostnader)
+
+PDF tips: "Det bästa sättet att visa att du har vinstsyfte är att redovisa åtminstone några intäkter och inte enbart kostnader."
+
+## Slutligt underskott vid avveckling
+
+When verksamhet upphör helt (verksamheten avslutas, alla tillgångar säljs):
+
+### Huvudregel
+
+Vid nedläggning av enskild näringsverksamhet:
+- 70% av slutligt underskott får utnyttjas som **kapitalförlust** i inkomstslaget kapital
+- Avdraget tas in i ruta **14.1 på baksidan av INK1**, året efter nedläggningsåret
+- Skattereduktion = 70% × 30% = **21%** skattereduktion på det kvarvarande underskottet
+
+Worked example (PDF):
+- Slutligt underskott 80 000 kr vid nedläggning
+- Inkomstdeklaration året efter: 70% × 80 000 = 56 000 kr som kapitalförlust
+- Skatteminskning = 30% × 56 000 = **16 800 kr** (motsvarar 21% av 80k)
+
+### Fördelning på 3 år
+
+Om inte tillräckligt med skatt att kvitta mot ett enda år, får avdraget delas på högst **3 år** (fördelningsåret + 2 år).
+
+Inte några marginaleffekter i inkomstslaget kapital → inget utrymme för skatteplanering på fördelning. Bäst att utnyttja skattereduktionen så snabbt som möjligt.
+
+### Year efter slutåret
+
+Avdraget får göras **först inkomståret efter** att verksamheten **helt** har avslutats. Praktiskt: nedlägg verksamheten 2025, lämna sista NE för 2025, sedan i deklarationen för **2026** dras 70% i kapital.
+
+### Restriktion vid ombildning till AB
+
+Om verksamheten ombildas till AB, kan underskottet **inte** föras över till AB:et — det är knutet till näringsidkaren personligen. Underskottet hanteras genom:
+- 70%-avdraget i kapital (om verksamheten faktiskt upphör)
+- ELLER om verksamheten *fortsätter parallellt* i AB och EF, finns ingen formell upphörande → underskottet rullas vidare i EF
+
+PDF restriction: "Möjligheterna till avdrag för slutligt underskott är dock begränsade vid en ombildning till ett aktiebolag eftersom tillgångarna förs ut ur den enskilda firman till underpris och det inte blivit någon uttagsbeskattning."
+
+This restriction prevents using a sham ombildning + nedläggning to convert future-rolling underskott into immediate kapitalförlust.
+
+## Dödsbon
+
+Same regler:
+- Verksamheten kan fortsätta efter dödsfall
+- Dödsboet kan ta över ansvar för kvarvarande underskott
+- Vid bouppteckning: om endast en dödsbodelägare → dödsboet anses skiftat redan vid bouppteckning → underskottet förloras
+- Vid flera dödsbodelägare → dödsboet kan leva vidare och utnyttja underskottet
+- Tip from PDF: vid risk för att underskott försvinner, gör **partiellt arvsavstående** för att skapa flera dödsbodelägare
+
+## Kvittning vid övergång passiv → aktiv
+
+PDF specific case: Christer har hyreshus (passiv) med underskott rullande.
+
+År 1: hyreshus, underskott 80 000 kr → rullas framåt (passiv → ingen kvittning mot tjänst)
+År 2: tillkommer ytterligare 50 000 kr underskott → rullas framåt → ackumulerat 130 000 kr
+År 3: Christer slutar sin anställning, skaffar nya fastighet och börjar arbeta i verksamheten ≥ 500 h/år → klassificeras som **aktiv**. Överskott 40 000 kr.
+
+Effekt: hela ackumulerade underskottet (130 000 kr) kan dras av (vanlig rullning), men dessutom kan resterande 90 000 kr av nettounderskottet (130 000 − 40 000 = 90 000) **kvittas mot tjänst** med allmänt avdrag — eftersom verksamheten är aktiv i bedömningsåret. PDF: "Att verksamheten har varit passiv under de föregående åren har ingen betydelse."
+
+### 5-årsgränsen — but Christer is past 5 years
+
+Det krävs aktiv NV. The 5-årsgränsen från nystartad ska gälla *från företagsstarten*. Om verksamheten startade aktivt → 5 år börjar då. Om verksamheten startade passivt och senare blir aktiv, är det oklart om 5 år räknas från start eller från övergång till aktiv. Skatteverkets ställningstagande (131 657367-11/111) ger guidance — verify exact tolkning.
+
+PDF case suggests: kvittning är möjlig så länge verksamheten är aktiv under bedömningsåret. But proceed with caution.
+
+## Komplettering med ny verksamhet
+
+Om du redan har EF (passiv eller efter 5-årsperioden) och vill **kunna kvitta mot tjänst** för en ny aktivitet:
+- Att lägga **ny verksamhet** i den befintliga EF:en blandar in den nya i samma näringsverksamhet → den nya verksamheten räknas **inte** som nystartad
+- Lösning: lägg den nya verksamheten i ett separat **handelsbolag** (HB) → nytt skattesubjekt → 5-årsregeln gäller från HB:ets start
+
+This is a powerful planning move för konsult som vill behålla EF för befintlig verksamhet men starta ny inriktning med kvittningsfördel.
+
+## Övertagande från närstående
+
+If you take over a verksamhet from a närstående (within 5 år innan din start):
+- Kvittningsregeln (5 år, 100k cap) gäller **endast om den närstående skulle ha fått kvitta** if de fortsatt
+- = arvtagaren ärver kvarvarande del av 5-årsperioden, inte hela 5 år ny
+
+Specialfall: om du tagit över via **helt och hållet köp** (inte gåva, arv, testamente) från **förälder** eller **far-/morförälder** → räknas verksamheten som **nystartad** → 5 nya år.
+
+Buying out parents at full marknadsvärde is therefore much mer förmånligt skatteplaneringsmässigt än att ärva (motsatsen mot vad man kan tro initialt).
+
+## Kvittning of olika delverksamheter
+
+Inom EF: alla delverksamheter slås automatiskt ihop till **en enda näringsverksamhet** (in Sverige + i vissa fall EU-länder). Detta innebär att överskott och underskott from olika delverksamheter automatiskt kvittas, vilket ger lägre eller ingen skatt och egenavgifter på överskottet.
+
+**Implication**: starting a profitable verksamhet samtidigt som man har en förlustverksamhet i samma EF → vinsten quenchas av förlusten utan ny ansökan eller särskild bokföring.
+
+PDF example: Bertil har AB med 520 000 kr vinst (skattas högt). Plus EF (hyreshus) med 100 000 kr förlust per år.
+- Option A: Behåll AB+EF → vinsten beskattas i AB, förlusten rullas i EF. Bertil får 299 000 kr efter skatt från AB-vinsten, plus 100 000 kr cash tillgängliga utan beskattning (eftersom EF-förlusten finansieras av AB-pengar via uttag).
+- Option B: skrota AB:et, lägg konsultverksamheten i EF:en med hyreshuset → sammanlagd vinst 420 000 kr → skatt+egenavg ~166 976 kr → **253 024 kr kvar** vs option A's 199 000 kr. Save 54 024 kr.
+
+This is the **biggest single argument for EF over AB** for low-to-mid income with concurrent förlustverksamhet.
+
+## NE-bilaga / INK1 rutor
+
+| Ruta | Innehåll |
+|---|---|
+| NE R24 | Inrullat underskott från föregående år |
+| NE R45 | Underskott som ska föras till allmänt avdrag (aktiv, nystartad, ≤ 100k) |
+| NE R47/R48 | Överskott / underskott av aktiv NV |
+| NE R49/R50 | Överskott / underskott av passiv NV |
+| INK1 14.1 | Allmänt avdrag för underskott i nystartad aktiv NV (sidan 2 baksida) |
+| INK1 14.1 (slutligt) | 70% av slutligt underskott i avslutad EF, året efter nedläggning |
+
+## Pitfalls
+
+1. **Likartad-verksamhet-spärr** — anti-omklassificering, kan utlösas av tidigare konsult-AB i samma bransch
+2. **Glömma rullning är ofta bättre än kvittning** — kvittning sparar bara skatt; rullning sparar skatt+egenavgifter
+3. **Slutligt underskott vid ombildning till AB** — tillgångarna förs ut till underpris → avdrag begränsas
+4. **Kulturarbetar-status** — 90–95%-krav måste kunna styrkas
+5. **Verksamhet anses skiftad vid bouppteckning** — enmansdödsbo, underskottet försvinner; lös med partiellt arvsavstående
+6. **Övertagande genom arv/gåva** — 5-årsperioden från överlåtaren räknas, inte ny 5-årsperiod
+7. **Glömma JSA-effekten av allmänt avdrag** — kvittning sänker underlaget för jobbskatteavdrag
+8. **Cap 100 000 kr räknas per år, inte över hela 5-årsperioden** — om du har 200 000 kr underskott år 1 och 0 underskott år 2–5, du kan bara dra 100 000 kr; resterande 100 000 kr måste rullas
+
+## Implementation checklist
+
+- [ ] Track verksamhetens *startdatum* (för 5-årsräkning)
+- [ ] Track aktiv vs passiv per år (för kvittningsrätt)
+- [ ] Track årligt allmänt avdrag mot 100 000 kr cap
+- [ ] Detect kulturarbetar-status (separat code path, no caps)
+- [ ] Detect ombildning till AB (begräns slutligt-underskott-avdraget)
+- [ ] Persist inrullat underskott carry-forward across years
+- [ ] Flag närstående-takeover via personnummer-relation check
+- [ ] Allow user to model alternative scenarios (kvittning vs rullning) for omprövning planning
+
+See also [[aktiv-passiv-naringsverksamhet]] (the prerequisite classification), [[ackumulerad-inkomst]] (annan metod att utjämna ojämn inkomst), and `swedish-year-end-closing` references/k1-forenklat-arsbokslut.md (NE-bilaga technical fields).

--- a/.claude/skills/swedish-ef-skatteplanering/references/periodiseringsfond-expansionsfond-ef.md
+++ b/.claude/skills/swedish-ef-skatteplanering/references/periodiseringsfond-expansionsfond-ef.md
@@ -1,0 +1,231 @@
+# Periodiseringsfond and Expansionsfond — EF Perspective
+
+## Legal basis
+
+- IL 30 kap — Periodiseringsfond (P-fond)
+- IL 34 kap — Expansionsfond
+- BFNAR 2006:1 — K1 (förbjuder bokföring av P-fond/expansionsfond för EF)
+
+For an AB-perspective on periodiseringsfond, see `swedish-tax-planning/references/periodiseringsfond.md`. The mechanics differ enough that they should be treated as separate systems.
+
+## Quick comparison: P-fond AB vs P-fond EF
+
+| Property | AB | EF |
+|---|---|---|
+| Max avsättning | 25% av skattemässigt överskott | **30%** av skattemässigt överskott |
+| Booked in räkenskaperna? | YES (8811/21xx) — formellt samband | **NO** (NE-bilaga only) |
+| Schablonintäkt | YES (SLR × IB av P-fonder, min 0,5%) | **NO** |
+| Antal parallella fonder | 6 | 6 |
+| Maximal carry | 6 år (FIFO återföring senast år 7) | 6 år (FIFO) |
+| Uppräkning på återföring (pre-2019) | YES (6%) | No equivalent |
+
+The most important EF-specific facts:
+1. **30%** (not 25%) — markedly more aggressive than AB
+2. **NO schablonintäkt** — the deferred tax sits genuinely 0%-räntefri for 6 years
+3. **NEVER booked in räkenskaperna** — only on NE-bilagan. Bokföring av P-fond gör avdraget ogiltigt för EF (omvänt mot AB!)
+
+## Periodiseringsfond EF mechanics
+
+### Avsättning
+
+- Max **30% of resultat efter räntefördelning, efter återföring av tidigare P-fond, och före egen P-fond avsättning och ändring av expansionsfond**
+- Each year creates its own fund (e.g., "periodiseringsfond 2025" — separately tracked)
+- Up to 6 fonder samtidigt
+
+### Återföring
+
+- Senast **år 7** (= 6:e året efter avsättningsåret) **måste** äldsta fond återföras
+- Återföringen är frivillig in earlier years
+- Tvingande återföring av samtliga fonder vid:
+  - Verksamhetens upphörande
+  - Skattskyldighetens upphörande vid utvandring utanför EU/EES
+  - Konkurs
+  - A-kassa (om man slutar för att få a-kasseersättning, då återförs)
+
+Vid flytt till EU/EES-land kan kontinuitet medges (EU-rätten).
+
+### Reporting on NE
+
+- Ruta **R34** — Återföring av periodiseringsfond
+- Ruta **R35** — Avsättning till periodiseringsfond
+- Upplysning U1 in förenklat årsbokslut: sammanlagda P-fonder vid årets slut
+
+### Worked example (PDF "Renata")
+
+A coronial example of poor planning: Renata builds 6 × 100 000 kr P-fond over six years, then realizes she's tomma på pengar in retirement and måste likvidera verksamheten. Hon måste återföra 600 000 kr, with tax ~240 000 kr, when hon already har spent the cash flow. Lesson: **always reserve 30–35% of P-fond ingång for the eventual tax bill**, e.g., on a separate bankkonto.
+
+Renata's recovery strategy: continue verksamheten in liten skala, do partial återföring + new avsättning each year (200 000 kr återförs, 30k ny avsättning → 170 000 kr beskattas årligen), spreading the bill over years 7–13.
+
+### Combining with räntefördelning at nedläggning
+
+Sparat fördelningsbelopp (positiv räntefördelning som sparats) may be used at nedläggning to offset återförd P-fond AND expansionsfond. This is the **largest single planning opportunity** for an EF closing down — see worked example "Lennart" in [[rantefordelning-planning]].
+
+### Tillfällig regel 2019 (COVID)
+
+For inkomstår 2019, 100% av vinsten fick avsättas till P-fond (one-time relief). Possible to retroactively use via omprövning of 2019 deklaration within 6 years (= until inkomstår 2025 deklaration filing window) if not already done.
+
+### SOU 2020:50 proposal (not enacted)
+
+- Höjd från 30% till **40%**
+- Förlängd carry från 6 till **10 år**
+- P-fond äldre than 6 år FÅR INTE överföras till AB vid ombildning (would be återförda direkt at takeover)
+
+## Expansionsfond mechanics
+
+### Purpose
+
+Expansionsfond gives EF the equivalent of an AB's ability to retain earnings at corporate-tax-rate. The fonderade vinsten beskattas with **20,6% expansionsfondsskatt** (same as bolagsskatt) and may be reinvested in verksamheten utan ytterligare beskattning. At återföring, the 20,6% credits back against that year's tax (so the net effect is just regular inkomstskatt on the återförda beloppet).
+
+### Avsättning rules
+
+- Skatt: **20,6%** expansionsfondsskatt
+- Tak: expansionsfonden får vara **högst 128,21% av kapitalunderlaget** vid årets utgång
+- Ökning av expansionsfond may NOT cause underskott in NV
+- Ökning beräknas på resultat efter räntefördelning, efter ändring av P-fond, och före ändring expansionsfond
+
+### Kapitalunderlag for expansionsfond
+
+Conceptually identical to kapitalunderlag for räntefördelning, with one key difference:
+- **Räntefördelning**: kapitalunderlag at *föregående* års utgång (= ingång aktuella året)
+- **Expansionsfond**: kapitalunderlag at *aktuella* årets utgång
+
+Practical tip: the year 2 expansionsfond kapitalunderlag will be similar to the year 3 räntefördelning kapitalunderlag, so the same beräkning may be reused with a one-year offset.
+
+### Återföring
+
+- May happen voluntarily at any point
+- Vid återföring ökar skattemässig inkomst, men 20,6% expansionsfondsskatt återbetalas
+- Vid förlustår: återföringen kan vara **skattefri** (the 20,6% återbetalas och resultatet blir 0 eller negativt → no extra inkomstskatt)
+- Vid kapitalunderlags-minskning under fondens nivå → tvingande återföring (delvis)
+- Vid företagets upphörande → all återförs samma år
+
+### NE-bilaga fields
+
+- Ruta **R36** — Återföring av expansionsfond i NV
+- Ruta **R37** — Ökning av expansionsfond
+- Sid 2 expansionsfondsbilaga **2196** for kapitalunderlagsberäkning (separately filed)
+- Upplysning U2 in förenklat årsbokslut: expansionsfond vid årets slut
+
+### Worked example (PDF "Georg")
+
+50 år, aktiv NV, vinst 800 000 kr, kapitalunderlagstak 400 000 kr för expansionsfond.
+
+Without expansionsfond:
+- Skatt och egenavgifter på 800 000 kr ≈ 236 000 kr (≈ 29,5%)
+
+With expansionsfond avsättning 100 000 kr:
+- Inkomst beskattad som NV: 700 000 kr → skatt och egenavgifter 189 492 kr
+- Expansionsfondsskatt: 20,6% × 100 000 = 20 600 kr
+- Total: 210 092 kr
+- **Sparat: 25 908 kr** at the cost of setting aside 100 000 kr (returnable later)
+
+### Carry-forward of skatt
+
+The 20,6% expansionsfondsskatt is paid in the year of avsättning. **It is NOT a deferral of inkomstskatt** — it's a final-tax on the avsättning. At återföring, the 20,6% credits back.
+
+### When expansionsfond is *not* worth it
+
+Same logic as räntefördelning:
+- Pensionärer (10,21% egenavgifter): low marginal NV tax may already be UNDER 20,6%
+- För inkomster under brytpunkten, marginalskatten kan vara så låg att expansionsfondsskatten 20,6% är högre
+
+**Heuristik**: only use expansionsfond when *current year* marginal skatt inkl egenavgifter > 20,6% AND *expected future return year* marginal skatt < current year marginal skatt.
+
+### Två-stegs beskattning vid utlöp
+
+If you build up expansionsfond at 20,6% and later take ut pengarna (instead of reinvesting):
+- Recovery → 42% (statlig + kommunal) − 20,6% = **21,4% extra skatt + egenavgifter** at återföringsåret
+
+So total skatt mot vad det vore som direkt löneuttag är samma, **bara om utbetalningen sker över brytpunkten i återföringsåret**. Under brytpunkten the math may favor expansionsfond (cheap retention) or löneuttag (cheap immediate).
+
+### Tvingande återföring
+
+- Vid upphörande av verksamheten (all of it)
+- Vid utvandring till icke-EES-land
+- Vid konkurs
+- Vid kapitalunderlagsminskning under fondens nivå
+- Vid byte av företagsform: kan överföras till AB *under förutsättning att samtliga realtillgångar överförs* OCH att tillgångar med skattemässigt värde ≥ 79,4% av expansionsfondens belopp överförs (motsvarar 100% − 20,6%)
+
+### SOU 2020:50 proposal (not enacted)
+
+- Expansionsfond föreslås **slopad** (avskaffad)
+- Befintliga fonder återförs med minst 10% per år under högst 10 år
+- Återföring beläggs med inkomstskatt men 20,6% återbetalas
+- Höjd P-fond (30 → 40%) som kompensation
+- Worth flagging as "watch this space"
+
+## Sjukpenninggrundande and pensionsgrundande inkomst effects
+
+This is the most subtle interaction. From the PDF (Sjukpenning section):
+
+> *"Men när Försäkringskassan beräknar din sjukpenninggrundande inkomst (SGI) och din föräldrapenninggrundande inkomst bortser man från de skattemässiga dispositionerna periodiseringsfond och expansionsfond."*
+
+| Disposition | SGI effekt | PGI effekt |
+|---|---|---|
+| Avsättning P-fond | INGEN (FK adjusts back) | Sänker PGI |
+| Återföring P-fond | INGEN (FK adjusts back) | Höjer PGI |
+| Avsättning expansionsfond | INGEN | Sänker PGI |
+| Återföring expansionsfond | INGEN | Höjer PGI |
+| Räntefördelning | Påverkar (positiv sänker, negativ höjer) | Påverkar |
+| Avskrivning på inventarier | Påverkar (höjd avskrivning sänker SGI och PGI) | Påverkar |
+| Mindre schablonavdrag egenavgifter | Höjer (paradoxalt) | Höjer |
+
+**Implication**: a näringsidkare with ojämn inkomst may use P-fond strategically to **smooth out PGI** (höja den i låga år, sänka i höga år) but NOT to smooth SGI (which Försäkringskassan adjusts back).
+
+Pensionsgrundande inkomst tak: **7,5 inkomstbasbelopp** (604 500 kr 2025). Income above this gives no extra pension but full egenavgifter. Use P-fond to keep PGI just under taket — see worked example "Laura":
+- Vinst 800 000 kr, after 25% schablonavdrag egenavgifter = 600 000 kr (nettoinkomst, would exceed PGI-tak 511 500 in 2021)
+- Avsättning 118 000 kr till P-fond → nettoinkomst sjunker till 682 000 → 511 500 → matches PGI-tak exactly
+- Future låginkomstår: lös upp P-fond för högre PGI då
+
+## Bokföringsförbudet (K1 / BFNAR 2006:1)
+
+EF must **NOT** book P-fond or expansionsfond in räkenskaperna — only as upplysning U1/U2 in förenklat årsbokslut, and via NE-bilagan. This is the **opposite** of AB (which MUST book P-fond).
+
+The reason: K1 is designed to keep redovisning aligned with real ekonomisk ställning, not skattemässig disposition. Latent skatteskuld is disclosed via U-poster, not booked.
+
+BAS 2018 Förenklat årsbokslut nevertheless has accounts available for those who *want* to track (2080 Periodiseringsfonder, 2050 Avsättning till expansionsfond, 2060 Ersättningsfond) — but they are for **informationssyfte only**, must not be debited/krediterad mot resultatkonton.
+
+For ersättningsfond, the situation is different: see [[ersattningsfond]].
+
+## Interactions with each other
+
+P-fond and expansionsfond are computed **in a specific order**:
+
+1. Compute skattemässigt resultat (R11 + R12–R26 justeringar = R31 inkomst före räntefördelning)
+2. Apply **räntefördelning** (R30) → result becomes inkomst efter räntefördelning
+3. Apply **återföring av P-fond** (R34) → increase result
+4. Apply **återföring av expansionsfond** (R36) → increase result
+5. Compute **30% cap for new P-fond avsättning** = 30% × (result after steps 1–4)
+6. Apply **avsättning ny P-fond** (R35) → decrease result
+7. Compute **expansionsfond ökning room** = result after step 6 (may not cause underskott)
+8. Apply **ökning expansionsfond** (R37) → decrease result
+9. Final: inkomst före schablonavdrag (R38)
+
+The exact ordering is enforced by NE-blankett layout. Note that the result *after* P-fond avsättning is the cap for expansionsfond ökning, so the two tools partly compete (every kr more in P-fond is one kr less expansionsfond room).
+
+### SOU 2020:50 proposes reversing the order — räntefördelning would be applied *last*, after P-fond. Not enacted.
+
+## Common pitfalls
+
+1. **Booking P-fond in EF räkenskaperna** — invaliderar avdraget (oppositional to AB where it's required)
+2. **Forgetting tvingande återföring** at upphörande — Skatteverket återför automatiskt and may apply skattetillägg
+3. **Calculating expansionsfond tak using prior year kapitalunderlag** — must be *current year's* utgång, not prior year's
+4. **Misunderstanding 128,21% multiplier** — it represents 1 / (1 − 0,206) = 100 / 79,4 = the gross-up factor that ensures the net-of-tax expansionsfond equals exactly kapitalunderlaget. Equivalent statement: expansionsfond *net of skatt* ≤ 100% av kapitalunderlag.
+5. **Skipping U1/U2 upplysning** in förenklat årsbokslut — formal compliance requirement under BFNAR 2006:1
+6. **Forgetting expansionsfond may NOT cause underskott** — software should clip ökning at the level that leaves NV result ≥ 0
+
+## Recommended planning sequence per inkomstår
+
+1. Compute provisional resultat
+2. Compute kapitalunderlag for räntefördelning (ingång) and expansionsfond (utgång)
+3. Decide whether positiv räntefördelning is net beneficial (see [[rantefordelning-planning]] decision tree)
+4. Decide P-fond avsättning to:
+   - Hit PGI tak (7,5 IBB ≈ 511 500 / 604 500 depending on year)
+   - Reserve for known future förlustår or låginkomstår
+5. Decide expansionsfond ökning to:
+   - Retain working capital for verksamheten
+   - Lower current marginal skatt below brytpunkten
+6. Sanity-check: total egenavgifter underlag still > 40 000 kr to qualify for nedsättning 7,5%
+7. Compute schablonavdrag egenavgifter (R43) and submit
+
+See also [[ackumulerad-inkomst]] for handling the upphörande year återföring lump sum, [[egenavgifter-sgi-pgi-jsa]] for nedsättning rules, and [[ef-vs-ab-breakeven]] for the comparison with corporate periodiseringsfond.

--- a/.claude/skills/swedish-ef-skatteplanering/references/periodiseringsfond-expansionsfond-ef.md
+++ b/.claude/skills/swedish-ef-skatteplanering/references/periodiseringsfond-expansionsfond-ef.md
@@ -46,29 +46,34 @@ Vid flytt till EU/EES-land kan kontinuitet medges (EU-rätten).
 
 ### Reporting on NE
 
-- Ruta **R34** — Återföring av periodiseringsfond
-- Ruta **R35** — Avsättning till periodiseringsfond
+- Ruta **R32** — Återföring av periodiseringsfond
+- Ruta **R33** — Överskott före avsättning till periodiseringsfond (= caps R34)
+- Ruta **R34** — Avsättning till periodiseringsfond (max 30 % av R33)
 - Upplysning U1 in förenklat årsbokslut: sammanlagda P-fonder vid årets slut
 
-### Worked example (PDF "Renata")
+### Pitfall: P-fond utan likvid reserv
 
-A coronial example of poor planning: Renata builds 6 × 100 000 kr P-fond over six years, then realizes she's tomma på pengar in retirement and måste likvidera verksamheten. Hon måste återföra 600 000 kr, with tax ~240 000 kr, when hon already har spent the cash flow. Lesson: **always reserve 30–35% of P-fond ingång for the eventual tax bill**, e.g., on a separate bankkonto.
+Scenario: P-fond-avsättning år 1-6 (totalt N kr), pengarna används i drift (inga kontanter kvar). År 7+ tvingande återföring av äldsta P-fond → skattebördan kan vara 40-50 % av återfört belopp utan motsvarande kassaflöde.
 
-Renata's recovery strategy: continue verksamheten in liten skala, do partial återföring + new avsättning each year (200 000 kr återförs, 30k ny avsättning → 170 000 kr beskattas årligen), spreading the bill over years 7–13.
+**Reserveringsregel**: vid varje P-fond-avsättning, sätt av 30-35 % av beloppet på separat konto (likvid reserv för framtida skattebörda).
+
+**Mitigation om man hamnat där**: fortsätt verksamheten i liten skala, gör partial återföring + ny avsättning varje år (t.ex. återför 200 000 / sätt av 30 000 → 170 000 nettoåterförs och beskattas årligen) → sprider skattebelastningen över år 7-13.
 
 ### Combining with räntefördelning at nedläggning
 
-Sparat fördelningsbelopp (positiv räntefördelning som sparats) may be used at nedläggning to offset återförd P-fond AND expansionsfond. This is the **largest single planning opportunity** for an EF closing down — see worked example "Lennart" in [[rantefordelning-planning]].
+Sparat fördelningsbelopp (positiv räntefördelning som sparats) får användas vid nedläggning för att kvitta återförd P-fond OCH expansionsfond. Detta är den **enskilt största planeringsmöjligheten** för en EF vid avveckling — se sparat-fördelningsbelopp-mekaniken i [[rantefordelning-planning]].
 
 ### Tillfällig regel 2019 (COVID)
 
 For inkomstår 2019, 100% av vinsten fick avsättas till P-fond (one-time relief). Possible to retroactively use via omprövning of 2019 deklaration within 6 years (= until inkomstår 2025 deklaration filing window) if not already done.
 
-### SOU 2020:50 proposal (not enacted)
+### SOU 2020:50 proposal — P-fond delarna **EJ genomförda**
+
+Höjningen från 30% till 40% och förlängd carry till 10 år låg på utredningens bord. **Inte enacted** via prop. 2024/25:1 (som främst genomförde RF-reformen — se [[rantefordelning-planning]] för det som faktiskt blev lag). Bevaka för framtida reformpaket.
 
 - Höjd från 30% till **40%**
 - Förlängd carry från 6 till **10 år**
-- P-fond äldre than 6 år FÅR INTE överföras till AB vid ombildning (would be återförda direkt at takeover)
+- P-fond äldre än 6 år FÅR INTE överföras till AB vid ombildning (would be återförda direkt at takeover)
 
 ## Expansionsfond mechanics
 
@@ -78,8 +83,8 @@ Expansionsfond gives EF the equivalent of an AB's ability to retain earnings at 
 
 ### Avsättning rules
 
-- Skatt: **20,6%** expansionsfondsskatt
-- Tak: expansionsfonden får vara **högst 128,21% av kapitalunderlaget** vid årets utgång
+- Skatt: **20,6%** expansionsfondsskatt (synkad med bolagsskatten)
+- Tak: expansionsfonden får vara **högst 125,94% av kapitalunderlaget** vid årets utgång (= 1 / (1 − 0,206) = 100 / 79,4 — gross-up-faktorn som säkerställer att fondens netto-värde efter expansionsfondsskatt = kapitalunderlaget)
 - Ökning av expansionsfond may NOT cause underskott in NV
 - Ökning beräknas på resultat efter räntefördelning, efter ändring av P-fond, och före ändring expansionsfond
 
@@ -101,23 +106,25 @@ Practical tip: the year 2 expansionsfond kapitalunderlag will be similar to the 
 
 ### NE-bilaga fields
 
-- Ruta **R36** — Återföring av expansionsfond i NV
-- Ruta **R37** — Ökning av expansionsfond
-- Sid 2 expansionsfondsbilaga **2196** for kapitalunderlagsberäkning (separately filed)
+- Ruta **R35** — Överskott före ökning av expansionsfond (= caps R37)
+- Ruta **R36** — Återföring av expansionsfond → INK1 p.12.1
+- Ruta **R37** — Ökning av expansionsfond → INK1 p.12.2
+- Hjälpblankett **SKV 2196** (Räntefördelning och expansionsfond) — used för kapitalunderlagsberäkning. **Lämnas INTE in** till Skatteverket; behåll som arbetspapper. Beräknade belopp överförs till NE och INK1.
 - Upplysning U2 in förenklat årsbokslut: expansionsfond vid årets slut
 
-### Worked example (PDF "Georg")
+### Expansionsfond — breakeven-exempel (siffror illustrativa)
 
-50 år, aktiv NV, vinst 800 000 kr, kapitalunderlagstak 400 000 kr för expansionsfond.
+Setup: aktiv EF under pensionsåldersgränsen, NV-vinst 800 000 kr, kapitalunderlagstak 400 000 kr → max-avsättning 400 000 × 1,2594 = ~503 000 kr.
 
-Without expansionsfond:
-- Skatt och egenavgifter på 800 000 kr ≈ 236 000 kr (≈ 29,5%)
+| Variabel | Utan expansionsfond | Med 100 000 kr avsättning |
+|---|---|---|
+| NV-beskattad inkomst | 800 000 | 700 000 |
+| Skatt + egenavgifter på NV-delen | ~236 000 | ~189 500 |
+| Expansionsfondsskatt (20,6 % × 100 000) | 0 | 20 600 |
+| **Total skatt år 1** | **~236 000** | **~210 100** |
+| **Sparat år 1** | — | **~25 900 kr** |
 
-With expansionsfond avsättning 100 000 kr:
-- Inkomst beskattad som NV: 700 000 kr → skatt och egenavgifter 189 492 kr
-- Expansionsfondsskatt: 20,6% × 100 000 = 20 600 kr
-- Total: 210 092 kr
-- **Sparat: 25 908 kr** at the cost of setting aside 100 000 kr (returnable later)
+Avsättning binder upp 100 000 kr i verksamheten (kan återföras senare → 20,6 % återbetalas mot återföringsårets skatt). Lönsamt när NV-marginalskatt år 1 > 20,6 %.
 
 ### Carry-forward of skatt
 
@@ -146,7 +153,9 @@ So total skatt mot vad det vore som direkt löneuttag är samma, **bara om utbet
 - Vid kapitalunderlagsminskning under fondens nivå
 - Vid byte av företagsform: kan överföras till AB *under förutsättning att samtliga realtillgångar överförs* OCH att tillgångar med skattemässigt värde ≥ 79,4% av expansionsfondens belopp överförs (motsvarar 100% − 20,6%)
 
-### SOU 2020:50 proposal (not enacted)
+### SOU 2020:50 proposal — expansionsfond-delarna **EJ genomförda**
+
+Slopningen av expansionsfond ingick i den större "näringsfond"-idén som SOU föreslog. **Inte enacted** — prop. 2024/25:1 begränsade sig till RF-reformen (se [[rantefordelning-planning]]). Expansionsfond består tills vidare.
 
 - Expansionsfond föreslås **slopad** (avskaffad)
 - Befintliga fonder återförs med minst 10% per år under högst 10 år
@@ -156,9 +165,7 @@ So total skatt mot vad det vore som direkt löneuttag är samma, **bara om utbet
 
 ## Sjukpenninggrundande and pensionsgrundande inkomst effects
 
-This is the most subtle interaction. From the PDF (Sjukpenning section):
-
-> *"Men när Försäkringskassan beräknar din sjukpenninggrundande inkomst (SGI) och din föräldrapenninggrundande inkomst bortser man från de skattemässiga dispositionerna periodiseringsfond och expansionsfond."*
+This is the most subtle interaction. Försäkringskassan bortser från de skattemässiga dispositionerna **periodiseringsfond och expansionsfond** vid beräkning av sjukpenninggrundande inkomst (SGI) och föräldrapenninggrundande inkomst — men de slår igenom på den pensionsgrundande inkomsten (PGI).
 
 | Disposition | SGI effekt | PGI effekt |
 |---|---|---|
@@ -172,10 +179,15 @@ This is the most subtle interaction. From the PDF (Sjukpenning section):
 
 **Implication**: a näringsidkare with ojämn inkomst may use P-fond strategically to **smooth out PGI** (höja den i låga år, sänka i höga år) but NOT to smooth SGI (which Försäkringskassan adjusts back).
 
-Pensionsgrundande inkomst tak: **7,5 inkomstbasbelopp** (604 500 kr 2025). Income above this gives no extra pension but full egenavgifter. Use P-fond to keep PGI just under taket — see worked example "Laura":
-- Vinst 800 000 kr, after 25% schablonavdrag egenavgifter = 600 000 kr (nettoinkomst, would exceed PGI-tak 511 500 in 2021)
-- Avsättning 118 000 kr till P-fond → nettoinkomst sjunker till 682 000 → 511 500 → matches PGI-tak exactly
-- Future låginkomstår: lös upp P-fond för högre PGI då
+PGI-tak (7,5 IBB): 2025 = 604 500 kr / 2026 = 625 500 kr. Inkomst över taket → 0 extra pension, full egenavgift (= ren skatt utan pensionsavkastning).
+
+PGI-utjämnings-strategy:
+```
+höginkomstår: avsätt (förväntad_PGI − tak) till P-fond → PGI sänks till exakt taket
+låginkomstår: återför P-fond → höjer PGI mot taket
+```
+
+PGI-beräkning: PGI = NV-resultat efter schablonavdrag (25 % aktiv / 20 % SLP / 10 % pensionär). Vid 800 000 kr brutto aktiv NV → PGI-grund 600 000 kr (under 2025/2026-taket, ingen avsättning behövs). Vid större brutto → räkna ut delta mot taket och avsätt motsvarande.
 
 ## Bokföringsförbudet (K1 / BFNAR 2006:1)
 
@@ -183,9 +195,9 @@ EF must **NOT** book P-fond or expansionsfond in räkenskaperna — only as uppl
 
 The reason: K1 is designed to keep redovisning aligned with real ekonomisk ställning, not skattemässig disposition. Latent skatteskuld is disclosed via U-poster, not booked.
 
-BAS 2018 Förenklat årsbokslut nevertheless has accounts available for those who *want* to track (2080 Periodiseringsfonder, 2050 Avsättning till expansionsfond, 2060 Ersättningsfond) — but they are for **informationssyfte only**, must not be debited/krediterad mot resultatkonton.
+BAS 2018 Förenklat årsbokslut har konton 2080 Periodiseringsfonder och 2050 Avsättning till expansionsfond för EF som *vill* spegla skattemässiga reserver i sin redovisning, men de är för **informationssyfte only** — får INTE debiteras/krediteras mot resultatkonton (förbudet ovan).
 
-For ersättningsfond, the situation is different: see [[ersattningsfond]].
+**Undantag: ersättningsfond (IL 31 kap).** Till skillnad från P-fond och expansionsfond **skall** ersättningsfondsavsättningen bokföras via resultaträkningen (debit 8xxx, credit **2060 Ersättningsfond**) för att avdraget ska vara giltigt. Detta gäller även för EF under K1. Se [[ersattningsfond]] för detaljer. Undantag: ersättningsfond för mark behöver inte bokföras enligt BFNAR 2006:1.
 
 ## Interactions with each other
 
@@ -203,14 +215,14 @@ P-fond and expansionsfond are computed **in a specific order**:
 
 The exact ordering is enforced by NE-blankett layout. Note that the result *after* P-fond avsättning is the cap for expansionsfond ökning, so the two tools partly compete (every kr more in P-fond is one kr less expansionsfond room).
 
-### SOU 2020:50 proposes reversing the order — räntefördelning would be applied *last*, after P-fond. Not enacted.
+### SOU 2020:50 proposes reversing the order — räntefördelning would be applied *last*, after P-fond. **Not enacted** (prop. 2024/25:1 ändrade RF-trösklarna men inte beräkningsordningen).
 
 ## Common pitfalls
 
 1. **Booking P-fond in EF räkenskaperna** — invaliderar avdraget (oppositional to AB where it's required)
 2. **Forgetting tvingande återföring** at upphörande — Skatteverket återför automatiskt and may apply skattetillägg
 3. **Calculating expansionsfond tak using prior year kapitalunderlag** — must be *current year's* utgång, not prior year's
-4. **Misunderstanding 128,21% multiplier** — it represents 1 / (1 − 0,206) = 100 / 79,4 = the gross-up factor that ensures the net-of-tax expansionsfond equals exactly kapitalunderlaget. Equivalent statement: expansionsfond *net of skatt* ≤ 100% av kapitalunderlag.
+4. **Misunderstanding 125,94 % multiplier** — it represents 1 / (1 − 0,206) = 100 / 79,4 ≈ 1,2594 = the gross-up factor that ensures the net-of-tax expansionsfond equals exactly kapitalunderlaget. Equivalent statement: expansionsfond *net of skatt* ≤ 100 % av kapitalunderlag. Äldre källor (före 2021) använder 128,21 % baserat på den dåvarande 22 % bolagsskatten; korrekt multiplikator vid nuvarande 20,6 % expansionsfondsskatt är 125,94 %.
 5. **Skipping U1/U2 upplysning** in förenklat årsbokslut — formal compliance requirement under BFNAR 2006:1
 6. **Forgetting expansionsfond may NOT cause underskott** — software should clip ökning at the level that leaves NV result ≥ 0
 

--- a/.claude/skills/swedish-ef-skatteplanering/references/rantefordelning-planning.md
+++ b/.claude/skills/swedish-ef-skatteplanering/references/rantefordelning-planning.md
@@ -4,9 +4,21 @@
 
 - IL 33 kap (Räntefördelning) — full chapter
 - IL 33 kap 2 § — applies to enskilda näringsidkare and svenska dödsbon
-- IL 33 kap 3 § — gränsbelopp ±50 000 kr
+- IL 33 kap 3 § — gränsbelopp (amended fr.o.m. 2025-01-01, see "2025 reform" below)
 - IL 33 kap 6 § — positiv räntefördelning frivillig
 - Prop 1993/94:50 sid 427 — introduced the system
+- **Prop. 2024/25:1 (budgetpropositionen 2025) — "Förbättrade skattemässiga villkor för enskilda näringsidkare"**: avskaffade 50 000 kr-tröskeln för positiv räntefördelning och höjde tröskeln för negativ räntefördelning till −500 000 kr, ikraft 1 januari 2025
+
+## 2025 reform — gränsbelopp omarbetade
+
+Det ursprungliga ±50 000 kr-systemet (gällande t.o.m. inkomstår 2024) är **inte längre i kraft**. Fr.o.m. inkomstår 2025 (deklaration 2026) gäller:
+
+| Regel | Före 2025 | Fr.o.m. 2025 |
+|---|---|---|
+| Positiv räntefördelning (frivillig) | Kapitalunderlag > **+50 000 kr** krävdes | **Tröskel slopad** — får göras om kapitalunderlag är positivt (≥ 0 kr) |
+| Negativ räntefördelning (obligatorisk) | Kapitalunderlag < **−50 000 kr** triggade | Triggas först om kapitalunderlag < **−500 000 kr** |
+
+Reformen kommer från SOU 2020:50 "Enklare skatteregler för enskild näringsverksamhet" och genomfördes delvis via prop. 2024/25:1.
 
 ## The fundamental idea
 
@@ -14,20 +26,20 @@ Räntefördelning shifts a *schablon* return on the kapital insatt i verksamhete
 
 The intent (1994 reform): align tax treatment of capital invested in EF with capital invested in AB (where a näringsidkare can lend money to the AB and get marknadsmässig ränta taxed at 30% in kapital).
 
-### Positiv räntefördelning (frivillig)
+### Positiv räntefördelning (frivillig) — 2025+
 
-- Kapitalunderlag > **+50 000 kr** at föregående års utgång
+- Kapitalunderlag **≥ 0 kr** at föregående års utgång (50 000 kr-tröskeln slopad fr.o.m. 2025)
 - Rate: **SLR + 6 procentenheter**
 - Effect: deduct kapitalunderlag × rate from NV income, add same amount as kapitalinkomst (30% tax)
 
-### Negativ räntefördelning (obligatorisk)
+### Negativ räntefördelning (obligatorisk) — 2025+
 
-- Kapitalunderlag < **−50 000 kr** at föregående års utgång
+- Kapitalunderlag **< −500 000 kr** at föregående års utgång (höjt från −50 000 kr fr.o.m. 2025)
 - Rate: **SLR + 1 procentenhet**
 - Effect: add belopp to NV income, deduct same as kapitalkostnad (30% skattereduktion)
 - **Cannot be skipped** — it is obligatorisk per IL 33 kap
 
-If kapitalunderlag is between −50 000 and +50 000 kr → **no räntefördelning at all** (absolute, not marginal — if you're at +50 001 you do räntefördelning on the *entire* 50 001 belopp, not on the 1 kr över gränsen).
+Mellan −500 000 och 0 kr → **ingen räntefördelning alls** (gränsen är absolut, inte marginell). Tidigare (≤ 2024) gällde ±50 000 kr som dubbelriktad gräns.
 
 ## Rates by year
 
@@ -36,7 +48,7 @@ Anchored to statslåneräntan (SLR) 30 november the year before income year.
 | Inkomstår | SLR Nov 30 prior year | Positiv rate (SLR+6) | Negativ rate (SLR+1) |
 |---|---|---|---|
 | 2021 | 0,23% | 6,5% | 1,5% (effektivt 1,51%) |
-| 2024 | (verify) | ~8% | ~3% |
+| 2024 | 2,62 % | 8,62 % | 3,62 % |
 | 2025 | 1,96% | **7,96%** | **2,96%** |
 | 2026 | 2,55% | **8,55%** | **3,55%** |
 
@@ -44,9 +56,7 @@ SLR may not go below 0,5% as floor (same floor as för schablonintäkt on P-fond
 
 ## When is positiv räntefördelning *worth* doing?
 
-This is the most consequential planning question, and the answer is "less often than people think". From the PDF:
-
-> *"Idag är det inte så säkert att skatt inklusive egenavgifter överstiger 30 procent, som är kapitalskatten på positivt räntefördelningsbelopp."*
+This is the most consequential planning question, and the answer is "less often than people think". Den faktiska NV-marginalskatten (kommunal + egenavgifter + ev. statlig) överstiger inte alltid kapitalskattens 30 % — räntefördelningen lönar sig bara när den gör det.
 
 ### Decision tree
 
@@ -54,33 +64,22 @@ This is the most consequential planning question, and the answer is "less often 
 2. **Under 65, under brytpunkten**: Marginalskatt ~46% inkl egenavgifter. Räntefördelning skattereduktion = (46% − 30%) ≈ 16 procentenheter. Small benefit, but pensions- och sjukpenninggrundande inkomst minskar. → MAYBE NOT worth it for low income; weigh against förlorad SGI/PGI.
 3. **Under 65, över brytpunkten**: Marginalskatt 52–65% inkl statlig och egenavgifter. Räntefördelning saves ~22–35 pp. → DO IT.
 
-### Worked examples (from PDF)
+### Decision table: lönar sig RF? (NV-vinst 100 000 kr, hela vinsten flyttad)
 
-#### Astrid, född 1936 (pensionär, no egenavgifter at all)
-Vinst 100 000 kr, total skatt utan räntefördelning 2 997 kr.
-With räntefördelning on entire 100 000: skatt = 30% × 100 000 = 30 000 kr.
-**Extra skatt: 27 003 kr.** → Don't do it.
+| Profil | NV-skatt utan RF (≈) | Med RF (30 % kap) | Delta | Beslut |
+|---|---|---|---|---|
+| Född 1937 eller tidigare (0 % avgift) | ~3 000 | 30 000 | +27 000 | RF FEL |
+| Pensionär 10,21 % egenavgift | ~10 700 | 30 000 | +19 300 | RF FEL |
+| Aktiv, under brytpunkt | ~23 600 | 30 000 | +6 400 | RF FEL |
+| Aktiv, över brytpunkt (vinst stor + tjänst) | ~74 500 (varav statlig ~20 %) | partial RF + rest NV | NEGATIV | RF RÄTT |
 
-#### Mimmi, född 1949 (pensionär, egenavgifter 10,21%)
-Vinst 100 000 kr, skatt utan räntefördelning 10 654 kr.
-With räntefördelning: 30 000 kr.
-**Extra skatt: 19 346 kr.** → Don't do it.
+Tröskel: RF lönar sig bara när NV-marginalskatt (kommunal + egenavgifter + ev. statlig) > 30 % kapital-skatt. Pensionärer + låginkomst-aktiva slår sällan över 30 % nettoeffekt. Aktiv över brytpunkten: 52–65 % marginal-NV → RF flyttar belopp från 52 % NV till 30 % kapital = stor besparing.
 
-#### Mirjam, född 1989 (full egenavgifter, vinst 100 000 kr)
-Skatt utan räntefördelning 23 606 kr.
-With räntefördelning: 30 000 kr.
-**Extra skatt: 6 394 kr.** → Don't do it (even though aktiv non-pensionär).
+### Sammanfattning
 
-#### Mirjam, but vinst is 250 000 kr (over brytpunkten because + tjänsteinkomst)
-Skatt utan räntefördelning 74 487 kr.
-With räntefördelning on entire vinst: 75 000 kr räntefördelningsbelopp + the rest in NV.
-**Net benefit: räntefördelning saves money once kapitalbeskattat belopp avoids statlig skatt on top of egenavgifter.**
-
-### Conclusion (PDF slutsatser)
-
-> *"För +65-åringar är det bättre att låta bli räntefördelningen."*
-> *"För övriga som inte betalar statlig skatt kan räntefördelningen innebära något lägre skatt än utan räntefördelning. Men även om räntefördelningen bara medför litet lägre skatt kan det ändå vara bättre att låta bli."*
-> *"För övriga som ligger över brytpunkten lönar det sig att använda räntefördelning."*
+- Pensionärer (≥ 65): låt bli räntefördelning — netto sämre i nästan alla scenarion
+- Under 65 men under brytpunkten: marginell vinst i bästa fall, ofta inte värt att tappa SGI/PGI
+- Under 65, över brytpunkten: räntefördela — kan flytta 22–35 pp marginalskatt till kapital
 
 In sum: positiv räntefördelning is only clearly beneficial when the näringsidkare is **below 65, has aktiv verksamhet, and has inkomst over brytpunkten för statlig inkomstskatt**.
 
@@ -132,17 +131,18 @@ Positiv räntefördelning need not be utnyttjat. The unused belopp:
 - Adds to kapitalunderlag next year → ränta-på-ränta effect
 - May be used at företagets nedläggning to offset återförd P-fond and expansionsfond (powerful exit-planning tool)
 
-Worked example (Ville, ur PDF):
-- Skogsinnehav, kapitalunderlag 800 000 kr, ingen lust att räntefördela mot 0-resultat
-- Räntefördelningsbelopp år 1: 800 000 × 7,15% = 57 200 kr → sparat
-- Kapitalunderlag år 2 grows by sparat belopp → 880 000 kr
-- Year 3 räntefördelning belopp = 880 000 × 6,99% = 61 512 kr → also sparas
-- Sparat ackumulerat ingång år 3: 118 712 kr
-- Year 3 säljer skog för 200 000 kr → resultat = 200 000 kr
-- Aktuellt års räntefördelning = 96 800 kr
-- Total available: 118 712 + 96 800 = 215 512 kr (cap = resultat = 200 000)
-- Use 200 000 kr → 200 000 × 30% = 60 000 kr i kapital (cheap), saving NV income from being taxed at 65%
-- Carry forward remaining 15 512 kr
+Mekanik:
+```
+år 1: RF_belopp = kapitalunderlag × (SLR + 6%)
+      om NV-resultat = 0 → hela RF_belopp sparas
+      sparat_ackumulerat = RF_belopp
+år N: kapitalunderlag_ingång += fjolårets sparat_belopp   # ränta-på-ränta
+      RF_belopp = kapitalunderlag × (SLR + 6%)
+      utnyttjat = min(sparat_ackumulerat + RF_belopp, NV_resultat)
+      sparat_ackumulerat = (sparat_ackumulerat + RF_belopp) − utnyttjat
+```
+
+Skogsägare-pattern: under låga/noll-resultatår låter man hela RF-beloppet sparas → stort ackumulerat utrymme. Vid avverkningsår (eller nedläggningsår) utnyttjas allt mot NV-resultatet → flyttar 200k–500k från NV-marginalskatt (~52 %) till kapital (30 %) = ~22–35 % effektiv besparing på det belopp som flyttas.
 
 ### Overtaking sparat räntefördelning
 
@@ -167,11 +167,11 @@ If kapitalunderlag was negativt 31 dec 1993 (when systemet infördes), a **över
 Övergångsposten:
 - Carries with bodelning, arv, gåva, testamente (helt övertagande)
 - Försvinner at *byte av företagsform* (e.g., EF → AB) and at *försäljning*
-- SOU 2020:50 proposes abolishing den
+- SOU 2020:50 föreslog avskaffande — **inte genomfört** via prop. 2024/25:1, övergångsposten består
 
 ### Särskild post (fastigheter erhållna med lån genom gåva)
 
-When you receive a fastighet i gåva and take över a lån that exceeds the fastighet's andel of skattemässigt kapitalunderlag, you may add a **särskild post** at gåvotillfället to undvika negativ räntefördelning. Only valid as long as the kapitalunderlag före den särskilda posten is positiv. Proposed slopad in SOU 2020:50.
+When you receive a fastighet i gåva and take över a lån that exceeds the fastighet's andel of skattemässigt kapitalunderlag, you may add a **särskild post** at gåvotillfället to undvika negativ räntefördelning. Only valid as long as the kapitalunderlag före den särskilda posten is positiv. SOU 2020:50 föreslog slopande — **inte genomfört** via prop. 2024/25:1, posten består.
 
 ## Alternative valuation rule for fastigheter
 
@@ -189,14 +189,14 @@ Jämkningsregeln: värdet via alternativregel ≤ 75% av byggnadsvärde, mark oc
 
 If makar driver gemensam EF:
 - Each make computes their *own* kapitalunderlag based on *their* andel av tillgångar/skulder
-- One make can deliberately own all problematic skulder, so the other has +50 001 räntefördelningsutrymme
+- Genom att låta ena maken äga skulder och andra maken äga tillgångar styrs hur stort kapitalunderlag respektive make har — och därmed hur stor positiv räntefördelning var och en kan göra
 
-Worked example (PDF): makar driva en liten verkstad. Fastighetsvärde 1 000 000 kr, skulder 920 000 kr, mannen äger maskiner 100 000 kr. Default fördelning 50/50 på fastigheten:
-- Manns kapitalunderlag: 0,5 × (1M − 920k) + 100k = 140 000 kr → får räntefördela
-- Kvinnans: 0,5 × (1M − 920k) = 40 000 kr → får INTE räntefördela (under 50k tröskel)
-- If de buy en maskin 15 000 kr och låter kvinnan köpa: hennes underlag blir 40k+15k = 55 000 kr → får räntefördela hela 55k
+Worked example (2025-regler, efter slopad +50 001-tröskel): makarna driver en liten verkstad. Fastighetsvärde 1 000 000 kr, skulder 920 000 kr, mannen äger maskiner 100 000 kr. Default 50/50-fördelning på fastigheten:
+- Mannens kapitalunderlag: 0,5 × (1M − 920k) + 100k = 140 000 kr → RF-belopp 2025 ≈ 11 144 kr
+- Kvinnans: 0,5 × (1M − 920k) = 40 000 kr → RF-belopp 2025 ≈ 3 184 kr
+- Om de istället köper en maskin 15 000 kr och låter kvinnan stå för den: hennes underlag 55 000 kr → RF-belopp 2025 ≈ 4 378 kr (≈ 1 200 kr större)
 
-This kind of fördelningsplanering is legitim under IL 33 kap.
+Sedan 50 001-tröskeln slopades 2025 handlar planeringen inte längre om att passera en gräns utan om att maximera respektive makes underlag inom kapital-skatt-bandet. Sådan fördelningsplanering är legitim under IL 33 kap.
 
 ## Pitfalls
 
@@ -207,15 +207,24 @@ This kind of fördelningsplanering is legitim under IL 33 kap.
 5. **Aktier antas vara tillgång i EF** — they are NOT (de hör till inkomstslaget kapital, not näringsverksamheten)
 6. **Insatsemissioner i ekonomisk förening** — only counted if förvärvade (not if mottagna gratis), because de motsvarar inte beskattade pengar
 
-## SOU 2020:50 simplification proposal (not enacted)
+## SOU 2020:50 — partial enactment (2025) + remaining proposals
 
-- Slopad övergångspost
-- Slopad särskild post för fastigheter
-- Räntesatsen för positiv räntefördelning föreslås sänkas till bara SLR (utan +6 pp)
-- Slopad negativ räntefördelning helt
-- Kapitalunderlag beräknas på utgång av året (inte ingång)
-- 50 000 kr gränsbelopp slopas
+SOU 2020:50 "Enklare skatteregler för enskild näringsverksamhet" har genomförts **delvis** via prop. 2024/25:1 (budgetpropositionen 2025, ikraft 2025-01-01):
 
-Worth flagging in software as a "watch this space" — if enacted, all rules above change materially.
+**Genomfört:**
+- ✅ **50 000 kr-gränsen för positiv räntefördelning slopad** (krävde tidigare kapitalunderlag > +50 000 kr; nu räcker ≥ 0 kr)
+- ✅ **Tröskeln för negativ räntefördelning höjd** till −500 000 kr (var −50 000 kr) — SOU föreslog total slopning, men reformen blev en höjd tröskel istället
+- ✅ Höjd schabloninventariegräns till halva PBB (var 5 000 kr)
+- ✅ Vissa förenklingar i förenklat årsbokslut
+
+**Inte genomfört** (kvarstår som förslag — bevaka):
+- ❌ Slopad övergångspost (post 1994)
+- ❌ Slopad särskild post för fastigheter erhållna genom gåva med lån
+- ❌ Räntesatsen för positiv räntefördelning sänkt till enbart SLR (utan +6 pp)
+- ❌ Total slopning av negativ räntefördelning
+- ❌ Kapitalunderlag beräknat på årets utgång (i stället för ingång)
+- ❌ Den större "näringsfond"-reformen (samlad ersättning för P-fond + expansionsfond + räntefördelning) — för komplex, lades på is efter remissrundan
+
+Worth flagging in software as a "watch this space" for the remaining proposals.
 
 See also [[periodiseringsfond-expansionsfond-ef]] (kapitalunderlag conceptually identical) and [[egenavgifter-sgi-pgi-jsa]] (SGI/PGI consequence of räntefördelning).

--- a/.claude/skills/swedish-ef-skatteplanering/references/rantefordelning-planning.md
+++ b/.claude/skills/swedish-ef-skatteplanering/references/rantefordelning-planning.md
@@ -1,0 +1,221 @@
+# Räntefördelning — Planning Reference for Enskild Firma
+
+## Legal basis
+
+- IL 33 kap (Räntefördelning) — full chapter
+- IL 33 kap 2 § — applies to enskilda näringsidkare and svenska dödsbon
+- IL 33 kap 3 § — gränsbelopp ±50 000 kr
+- IL 33 kap 6 § — positiv räntefördelning frivillig
+- Prop 1993/94:50 sid 427 — introduced the system
+
+## The fundamental idea
+
+Räntefördelning shifts a *schablon* return on the kapital insatt i verksamheten from inkomstslaget näringsverksamhet (taxed at marginal rates up to ~65% inclusive of egenavgifter) to inkomstslaget kapital (flat 30%). It's a paper allocation only — no money moves.
+
+The intent (1994 reform): align tax treatment of capital invested in EF with capital invested in AB (where a näringsidkare can lend money to the AB and get marknadsmässig ränta taxed at 30% in kapital).
+
+### Positiv räntefördelning (frivillig)
+
+- Kapitalunderlag > **+50 000 kr** at föregående års utgång
+- Rate: **SLR + 6 procentenheter**
+- Effect: deduct kapitalunderlag × rate from NV income, add same amount as kapitalinkomst (30% tax)
+
+### Negativ räntefördelning (obligatorisk)
+
+- Kapitalunderlag < **−50 000 kr** at föregående års utgång
+- Rate: **SLR + 1 procentenhet**
+- Effect: add belopp to NV income, deduct same as kapitalkostnad (30% skattereduktion)
+- **Cannot be skipped** — it is obligatorisk per IL 33 kap
+
+If kapitalunderlag is between −50 000 and +50 000 kr → **no räntefördelning at all** (absolute, not marginal — if you're at +50 001 you do räntefördelning on the *entire* 50 001 belopp, not on the 1 kr över gränsen).
+
+## Rates by year
+
+Anchored to statslåneräntan (SLR) 30 november the year before income year.
+
+| Inkomstår | SLR Nov 30 prior year | Positiv rate (SLR+6) | Negativ rate (SLR+1) |
+|---|---|---|---|
+| 2021 | 0,23% | 6,5% | 1,5% (effektivt 1,51%) |
+| 2024 | (verify) | ~8% | ~3% |
+| 2025 | 1,96% | **7,96%** | **2,96%** |
+| 2026 | 2,55% | **8,55%** | **3,55%** |
+
+SLR may not go below 0,5% as floor (same floor as för schablonintäkt on P-fond AB).
+
+## When is positiv räntefördelning *worth* doing?
+
+This is the most consequential planning question, and the answer is "less often than people think". From the PDF:
+
+> *"Idag är det inte så säkert att skatt inklusive egenavgifter överstiger 30 procent, som är kapitalskatten på positivt räntefördelningsbelopp."*
+
+### Decision tree
+
+1. **Pensionärer (≥65 år, full pension hela året)**: Egenavgifter only 10,21%; combined skatt ofta UNDER 30%. → DO NOT räntefördela. Räntefördelning *increases* total skatt for pensionärer in most income brackets.
+2. **Under 65, under brytpunkten**: Marginalskatt ~46% inkl egenavgifter. Räntefördelning skattereduktion = (46% − 30%) ≈ 16 procentenheter. Small benefit, but pensions- och sjukpenninggrundande inkomst minskar. → MAYBE NOT worth it for low income; weigh against förlorad SGI/PGI.
+3. **Under 65, över brytpunkten**: Marginalskatt 52–65% inkl statlig och egenavgifter. Räntefördelning saves ~22–35 pp. → DO IT.
+
+### Worked examples (from PDF)
+
+#### Astrid, född 1936 (pensionär, no egenavgifter at all)
+Vinst 100 000 kr, total skatt utan räntefördelning 2 997 kr.
+With räntefördelning on entire 100 000: skatt = 30% × 100 000 = 30 000 kr.
+**Extra skatt: 27 003 kr.** → Don't do it.
+
+#### Mimmi, född 1949 (pensionär, egenavgifter 10,21%)
+Vinst 100 000 kr, skatt utan räntefördelning 10 654 kr.
+With räntefördelning: 30 000 kr.
+**Extra skatt: 19 346 kr.** → Don't do it.
+
+#### Mirjam, född 1989 (full egenavgifter, vinst 100 000 kr)
+Skatt utan räntefördelning 23 606 kr.
+With räntefördelning: 30 000 kr.
+**Extra skatt: 6 394 kr.** → Don't do it (even though aktiv non-pensionär).
+
+#### Mirjam, but vinst is 250 000 kr (over brytpunkten because + tjänsteinkomst)
+Skatt utan räntefördelning 74 487 kr.
+With räntefördelning on entire vinst: 75 000 kr räntefördelningsbelopp + the rest in NV.
+**Net benefit: räntefördelning saves money once kapitalbeskattat belopp avoids statlig skatt on top of egenavgifter.**
+
+### Conclusion (PDF slutsatser)
+
+> *"För +65-åringar är det bättre att låta bli räntefördelningen."*
+> *"För övriga som inte betalar statlig skatt kan räntefördelningen innebära något lägre skatt än utan räntefördelning. Men även om räntefördelningen bara medför litet lägre skatt kan det ändå vara bättre att låta bli."*
+> *"För övriga som ligger över brytpunkten lönar det sig att använda räntefördelning."*
+
+In sum: positiv räntefördelning is only clearly beneficial when the näringsidkare is **below 65, has aktiv verksamhet, and has inkomst over brytpunkten för statlig inkomstskatt**.
+
+## Kapitalunderlag — what counts
+
+Kapitalunderlag = tillgångar minus skulder i verksamheten at föregående års utgång (= ingång of current year).
+
+### Tillgångar that count
+- Likvida medel (kassa, bankkonton in SEK or utländsk valuta used in business)
+- Specialinlåning på bank (jämställt with bankkonto)
+- Insättningar på Riksgäldskonto, realränteobligationer, marknadsnoterade fordringar in korta papper, certifikat och växlar
+- Kundfordringar (taken at deklarationsvärde — net of doubtful)
+- Varulager (taken at deklarationsvärde — net of inkurans, before any value adjustment)
+- Inventarier (taken at **skattemässig restvärde**)
+- Immateriella tillgångar (skattemässig restvärde)
+- Näringsfastigheter (huvudregeln: anskaffningsutgift minus avskrivningar; alternativregeln: % of taxeringsvärde 1993, see below)
+- Näringsbostadsrätter (anskaffningsvärdet)
+- Andelar i kooperativa föreningar (insatser; insatsemissioner only if förvärvade)
+- Medel på skogskonto, skogsskadekonto, upphovsmannakonto: **halva beloppet** (latent skatt)
+- Momsfordran
+
+### Tillgångar that DO NOT count
+- Aktier, konvertibla skuldebrev, marknadsnoterade kapitalmarknadspapper (NOT räknas — they belong to inkomstslaget kapital)
+- Privatbostadsfastigheter
+- Andelar i handelsbolag (always in HB, not the EF underlag)
+- Ej förvärvade insatsemissioner (de motsvarar inte skattat kapital)
+
+### Skulder that minska kapitalunderlaget
+- Banklån used in verksamheten
+- Leverantörsskulder
+- Upplupna räntekostnader, pensions-/garantiavsättningar, upplupna löner och arbetsgivaravgifter, förskott från kunder
+- Avsättning till ersättningsfond
+- Avsättning till periodiseringsfond
+- (Expansionsfondsskatten räknas EJ som skuld)
+
+### Items that are NEITHER tillgång NOR skuld
+- Inkomstskatt, egenavgifter, SLP, fastighetsskatt, kommunal fastighetsavgift, skattetillägg och förseningsavgifter (skatter i ren mening)
+
+### Justeringar to apply
+- **Sparade inrullade underskott** (not kvittade against kapitalvinst på näringsfastighet) → läggs till (acts as tillgång — restores eget kapital)
+- **Sparat fördelningsbelopp** from prior years → läggs till
+- **Tillfälliga kapitaltillskott** under previous 12 months → drar bort (only varaktiga insättningar count)
+
+## Sparat fördelningsbelopp
+
+Positiv räntefördelning need not be utnyttjat. The unused belopp:
+- May be saved → **sparat fördelningsbelopp**
+- Carries forward indefinitely
+- Adds to kapitalunderlag next year → ränta-på-ränta effect
+- May be used at företagets nedläggning to offset återförd P-fond and expansionsfond (powerful exit-planning tool)
+
+Worked example (Ville, ur PDF):
+- Skogsinnehav, kapitalunderlag 800 000 kr, ingen lust att räntefördela mot 0-resultat
+- Räntefördelningsbelopp år 1: 800 000 × 7,15% = 57 200 kr → sparat
+- Kapitalunderlag år 2 grows by sparat belopp → 880 000 kr
+- Year 3 räntefördelning belopp = 880 000 × 6,99% = 61 512 kr → also sparas
+- Sparat ackumulerat ingång år 3: 118 712 kr
+- Year 3 säljer skog för 200 000 kr → resultat = 200 000 kr
+- Aktuellt års räntefördelning = 96 800 kr
+- Total available: 118 712 + 96 800 = 215 512 kr (cap = resultat = 200 000)
+- Use 200 000 kr → 200 000 × 30% = 60 000 kr i kapital (cheap), saving NV income from being taxed at 65%
+- Carry forward remaining 15 512 kr
+
+### Overtaking sparat räntefördelning
+
+Sparat fördelningsbelopp may be **överlåtet** at:
+- Bodelning (separation/divorce)
+- Arv (inheritance)
+- Gåva and other **benefika fång** (the recipient pays little or nothing)
+
+The kapitalunderlag must justify the overtagaren in mottagandeåret. Note Skatteverket says the year of takeover may not be the year of utnyttjande unless the recipient already had sufficient kapitalunderlag from prior year.
+
+## Negativ räntefördelning planning
+
+Less flexibility (obligatorisk), but worth considering:
+- A pensionär with negativ kapitalunderlag pays 24,26% SLP and gets jämfört 30% skattereduktion — **net 5,74% benefit**, weird but real
+- Strategy: avoid running negativ kapitalunderlag if egenavgifter are full (28,97%) — kostar mer än kapitalskattereduktion ger
+- Restructuring tip: pay back lån used for private purposes before årsskiftet so de inte räknas som näringsskuld
+
+### Övergångspost (1994)
+
+If kapitalunderlag was negativt 31 dec 1993 (when systemet infördes), a **övergångspost** equal to the negativa belopp was fastställt. This adds to kapitalunderlag every year (effectively acts as a permanent tillgång), preventing onödig negativ räntefördelning from the legacy negativa eget kapital.
+
+Övergångsposten:
+- Carries with bodelning, arv, gåva, testamente (helt övertagande)
+- Försvinner at *byte av företagsform* (e.g., EF → AB) and at *försäljning*
+- SOU 2020:50 proposes abolishing den
+
+### Särskild post (fastigheter erhållna med lån genom gåva)
+
+When you receive a fastighet i gåva and take över a lån that exceeds the fastighet's andel of skattemässigt kapitalunderlag, you may add a **särskild post** at gåvotillfället to undvika negativ räntefördelning. Only valid as long as the kapitalunderlag före den särskilda posten is positiv. Proposed slopad in SOU 2020:50.
+
+## Alternative valuation rule for fastigheter
+
+For fastigheter förvärvade *före 1991*, anskaffningsvärdet may be låg. Alternative: use a % of taxeringsvärde 1993:
+- Småhusenheter: **54%**
+- Hyreshusenheter: **48%**
+- Industrienheter: **64%**
+- Lantbruksenheter: **39%** of taxeringsvärdet (for non-småhus parts)
+
+Värdeminskningsavdrag (avskrivningar) 1982–1993 above 10% of det framräknade anskaffningsvärdet → dras av. Avskrivningar 1994+ → dras av oavsett belopp.
+
+Jämkningsregeln: värdet via alternativregel ≤ 75% av byggnadsvärde, mark och markanläggningar' marknadsvärde.
+
+## Makar — fördelning av tillgångar och skulder
+
+If makar driver gemensam EF:
+- Each make computes their *own* kapitalunderlag based on *their* andel av tillgångar/skulder
+- One make can deliberately own all problematic skulder, so the other has +50 001 räntefördelningsutrymme
+
+Worked example (PDF): makar driva en liten verkstad. Fastighetsvärde 1 000 000 kr, skulder 920 000 kr, mannen äger maskiner 100 000 kr. Default fördelning 50/50 på fastigheten:
+- Manns kapitalunderlag: 0,5 × (1M − 920k) + 100k = 140 000 kr → får räntefördela
+- Kvinnans: 0,5 × (1M − 920k) = 40 000 kr → får INTE räntefördela (under 50k tröskel)
+- If de buy en maskin 15 000 kr och låter kvinnan köpa: hennes underlag blir 40k+15k = 55 000 kr → får räntefördela hela 55k
+
+This kind of fördelningsplanering is legitim under IL 33 kap.
+
+## Pitfalls
+
+1. **Ingen räntefördelning första året** — räntefördelning kräver att kapitalunderlag finns vid ingång av räkenskapsåret, vilket nystartad verksamhet inte har (Skatteverket Dnr 131 315797-06/111)
+2. **Forgetting tillfälliga kapitaltillskott reduction** — putting in 50 000 kr i december and taking out 50 000 kr in january does NOT permanently increase kapitalunderlag → måste eliminera tillskott som inte är varaktiga
+3. **Jämkning vid förkortat räkenskapsår** — om räkenskapsåret är 8/12 mån, fördelningsbeloppet jämkas till 8/12 av schablonen
+4. **Konfundera anskaffningsvärde med deklarationsvärde** för kundfordringar och varulager (correct value is the *skattemässiga* värdet)
+5. **Aktier antas vara tillgång i EF** — they are NOT (de hör till inkomstslaget kapital, not näringsverksamheten)
+6. **Insatsemissioner i ekonomisk förening** — only counted if förvärvade (not if mottagna gratis), because de motsvarar inte beskattade pengar
+
+## SOU 2020:50 simplification proposal (not enacted)
+
+- Slopad övergångspost
+- Slopad särskild post för fastigheter
+- Räntesatsen för positiv räntefördelning föreslås sänkas till bara SLR (utan +6 pp)
+- Slopad negativ räntefördelning helt
+- Kapitalunderlag beräknas på utgång av året (inte ingång)
+- 50 000 kr gränsbelopp slopas
+
+Worth flagging in software as a "watch this space" — if enacted, all rules above change materially.
+
+See also [[periodiseringsfond-expansionsfond-ef]] (kapitalunderlag conceptually identical) and [[egenavgifter-sgi-pgi-jsa]] (SGI/PGI consequence of räntefördelning).

--- a/.claude/skills/swedish-tax-planning/SKILL.md
+++ b/.claude/skills/swedish-tax-planning/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: swedish-tax-planning
 description: >
-  Swedish corporate tax planning for AB: periodiseringsfond (IL 30 kap, 25% avsättning, 6-year reversal, schablonintäkt), överavskrivningar (30-regeln/20-regeln, BAS 2150/8850), koncernbidrag (IL 35 kap, >90% ownership), 3:12-reglerna (gränsbelopp, K10, löneunderlag, 2026 reform), ränteavdragsbegränsningar (EBITDA 30%, förenklingsregeln 5 MSEK), kapitalförsäkring (avkastningsskatt, breakeven), and lön-vs-utdelning optimization. Trigger on periodiseringsfond, överavskrivning, koncernbidrag, 3:12, fåmansbolag, gränsbelopp, K10, löneunderlag, ränteavdrag, EBITDA-regeln, kapitalförsäkring, skatteplanering, or tax optimization for Swedish AB. Always use over training data.
+  Swedish corporate tax planning for AB. Scope: aktiebolag (AB) only. For enskild firma tax planning, use swedish-ef-skatteplanering. Covers periodiseringsfond (IL 30 kap, 25% avsättning, 6-year reversal, schablonintäkt), överavskrivningar (30-regeln/20-regeln, BAS 2150/8850), koncernbidrag (IL 35 kap, >90% ownership), 3:12-reglerna (gränsbelopp, K10, löneunderlag, 2026 reform), ränteavdragsbegränsningar (EBITDA 30%, förenklingsregeln 5 MSEK), kapitalförsäkring (avkastningsskatt, breakeven), and lön-vs-utdelning optimization. Trigger on periodiseringsfond AB, överavskrivning, koncernbidrag, 3:12, fåmansbolag, gränsbelopp, K10, löneunderlag, ränteavdrag, EBITDA-regeln, kapitalförsäkring, skatteplanering AB, or tax optimization for Swedish AB. Always use over training data.
 ---
 
 # Swedish Tax Planning (Skatteplanering AB)
 
 Developer-facing compliance reference for implementing Swedish corporate tax planning tools. Covers the major tax deferral and optimization instruments available to aktiebolag, their interactions, and compliance requirements.
+
+**Scope**: this skill is **AB-only**. For tax planning in enskild firma (sole proprietorship) — including räntefördelning, expansionsfond, EF-specific periodiseringsfond rules (30% / no schablonintäkt / never booked), egenavgifter, kvittning av underskott, inkomstuppdelning i familj, and ackumulerad inkomst — use the sister skill `swedish-ef-skatteplanering`. The mechanisms differ fundamentally between the two entity types, and this skill does not cover EF-specific rules.
 
 ## How to use this skill
 

--- a/.claude/skills/swedish-year-end-closing/SKILL.md
+++ b/.claude/skills/swedish-year-end-closing/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: swedish-year-end-closing
 description: >
-  Swedish year-end closing (bokslut) for AB and Enskild firma. Covers legal framework (BFL/ÅRL/K2/K3), step-by-step closing with BAS account numbers, all bokslutstransaktioner, tax calculations (bolagsskatt, egenavgifter, räntefördelning, expansionsfond, periodiseringsfond), reporting (årsredovisning/NE-bilaga), filing deadlines, SIE4 export, K2 vs K3 differences, and compliance pitfalls. Trigger on bokslut, årsbokslut, årsredovisning, closing entries, resultatdisposition, year-end accruals, tax provisions, överavskrivningar, accounts 2099/2091/8910/8811/2512/21xx/29xx in closing context, or any question about closing books for a Swedish company. Also trigger for "how do I book tax at year-end", "periodiseringsfond AB vs EF", "deadline årsredovisning", "what accounts for accruals".
+  Swedish year-end closing (bokslut) for AB and Enskild firma. Covers legal framework (BFL/ÅRL/K1/K2/K3), step-by-step closing with BAS account numbers, bokslutstransaktioner, tax calculations (bolagsskatt, egenavgifter, räntefördelning, expansionsfond, periodiseringsfond), reporting (årsredovisning/NE-bilaga), filing deadlines, SIE4 export, K2 vs K3 differences, förenklat årsbokslut K1 (BFNAR 2006:1, B-poster, R-poster, U-poster, BAS 2018 förenklat, NE-blankett mapping), and compliance pitfalls. Trigger on bokslut, årsbokslut, årsredovisning, förenklat årsbokslut, K1, BFNAR 2006:1, B-poster B1-B16, R-poster R1-R11, U-poster U1-U4, BAS 2018 förenklat, NE-blankett mapping, closing entries, resultatdisposition, accruals, tax provisions, överavskrivningar, accounts 2099/2091/8910/8811/2512/21xx/29xx, or any question about closing books for a Swedish company. Also "periodiseringsfond AB vs EF", "deadline årsredovisning", "K1 vs fullt årsbokslut".
 ---
 
 # Swedish Year-End Closing (Bokslut)
@@ -11,7 +11,7 @@ This skill provides everything needed to perform or implement a complete Swedish
 ## Quick decision tree
 
 1. **AB** → always årsredovisning → K2 (if mindre and eligible) or K3
-2. **Enskild firma, revenue ≤ 3 MSEK** → K1 förenklat årsbokslut
+2. **Enskild firma, revenue ≤ 3 MSEK** → **K1 förenklat årsbokslut** (BFNAR 2006:1) — see `references/k1-forenklat-arsbokslut.md`. Critical: P-fond and expansionsfond must NEVER be booked in räkenskaperna for EF (only as upplysning U1/U2); the opposite of AB. NE-bilaga handles the avdrag.
 3. **Enskild firma, revenue > 3 MSEK** → full årsbokslut (BFNAR 2017:3)
 
 ## Reference files
@@ -25,6 +25,7 @@ This skill contains detailed reference material split by topic. Read the relevan
 - **`references/reporting-and-filing.md`** — Årsredovisning structure, NE-bilaga, filing deadlines, penalties, Bolagsverket/Skatteverket requirements, SIE4 export, audit thresholds
 - **`references/k2-vs-k3.md`** — Implementation differences: component depreciation, deferred tax, intangibles, leasing, format restrictions, account visibility
 - **`references/pitfalls-and-rates.md`** — Common mistakes, compliance traps, kontrollbalansräkning, and reference rate table (2025/2026)
+- **`references/k1-forenklat-arsbokslut.md`** — K1 förenklat årsbokslut (BFNAR 2006:1): applicability (3 MSEK threshold), kontantmetoden vs faktureringsmetoden, B1-B16/R1-R11/U1-U4 struktur with BAS 2018 förenklat kontoplan mappings, K1 värderingsregler (inventarier, lager, skogskonto), NE-bilaga mapping, värdering at avveckling, and a distilled praktikfall
 
 ## How to use this skill
 

--- a/.claude/skills/swedish-year-end-closing/references/k1-forenklat-arsbokslut.md
+++ b/.claude/skills/swedish-year-end-closing/references/k1-forenklat-arsbokslut.md
@@ -1,0 +1,470 @@
+# K1 — Förenklat Årsbokslut för Enskild Näringsverksamhet
+
+## Legal basis
+
+- BFL (Bokföringslagen 1999:1078) 6 kap 6 § — möjlighet att upprätta förenklat årsbokslut
+- BFNAR 2006:1 — "Enskilda näringsidkare som upprättar förenklat årsbokslut" (K1) full vägledning
+- BFL 5 kap — verifikationer
+- BFL 7 kap — arkivering
+
+## Applicability — who may use K1?
+
+K1 (förenklat årsbokslut) is **available only** to:
+- **Enskild näringsidkare** (sole trader) — *not AB, HB, KB, ekonomisk förening, stiftelse, eller dödsbo som driver verksamhet*
+- Whose **årlig nettoomsättning normally does not exceed 3 000 000 kr** (3 MSEK)
+
+Above 3 MSEK or for non-sole-trader entities, **fullt årsbokslut** must be drawn up enligt BFNAR 2017:3 (K2/K3 equivalent for non-AB).
+
+### Multiple verksamheter
+
+If the same person runs multiple verksamheter:
+- Aggregera all verksamheter when comparing to 3 MSEK threshold
+- If aggregated > 3 MSEK → ALL must use fullt årsbokslut
+- If aggregated ≤ 3 MSEK → may use K1 for all of them
+
+### Enkelt bolag
+
+If multiple personer arbetar gemensamt i ett enkelt bolag:
+- Track-aggregeras per delägare → each delägare's share räknas mot 3 MSEK
+- If en delägares andel > 3 MSEK, samme delägare måste lämna fullt årsbokslut — och om så är fallet, alla delägare ska lämna fullt årsbokslut för den gemensamma verksamheten (PDF: "Följer man reglerna om förenklat årsbokslut i en verksamhet måste samma regler också tillämpas för de övriga verksamheterna")
+
+## Räkenskapsåret
+
+Enskild näringsverksamhet får bara ha **kalenderår** (1 jan – 31 dec) som räkenskapsår. Brutet räkenskapsår får INTE användas.
+
+Vid företagets start får första räkenskapsåret förkortas eller förlängas så att det slutar 31 december — **dock max 18 månader långt**. Vid avveckling får sista räkenskapsåret förkortas (inte förlängas).
+
+## Kontantmetoden vs faktureringsmetoden
+
+K1 allows **either** löpande bokföringsmetod:
+
+### Kontantmetoden
+
+- Endast in- och utbetalningar bokförs löpande under året
+- Vid årets slut bokförs alla obetalda kund- och leverantörsfakturor som bokslutstransaktioner
+- Tillåten om **årlig nettoomsättning ≤ 3 MSEK** (BFL 5 kap 2 §)
+- Praktisk fördel: mycket enklare löpande bokföring
+- Praktisk nackdel: balansräkningen visar inte rätt under året, bara vid bokslut
+
+### Faktureringsmetoden
+
+- Alla affärshändelser bokförs när de inträffar (faktura skickas / mottas)
+- Huvudregel i bokföringslagen (BFL 5 kap 1 §)
+- Krävs för företag > 3 MSEK omsättning
+
+## Förenklat årsbokslut — struktur
+
+The förenklat årsbokslut consists of:
+- A **balansräkning** (B-poster + B10 eget kapital)
+- A **resultaträkning** (R-poster R1 till R11)
+- A set of **U-poster** (U1–U4 upplysningar om obeskattade reserver)
+
+These are submitted (informellt — för dokumentation; **inte registreras hos Bolagsverket**) and act as the bridge to NE-bilagan i deklarationen.
+
+### Balansräkning struktur
+
+**Anläggningstillgångar:**
+| Post | Innehåll |
+|---|---|
+| **B1** | Immateriella anläggningstillgångar (rättigheter, patent, licenser, hemsidor, varumärken, franchiseavtal, goodwill) |
+| **B2** | Byggnader och markanläggningar |
+| **B3** | Mark och andra tillgångar som inte får skrivas av (mark, konst, antikviteter) |
+| **B4** | Maskiner och inventarier |
+| **B5** | Övriga anläggningstillgångar (andelar i ekonomiska föreningar, andelar i kooperativa föreningar) |
+
+**Omsättningstillgångar:**
+| Post | Innehåll |
+|---|---|
+| **B6** | Varulager |
+| **B7** | Kundfordringar |
+| **B8** | Övriga fordringar (förskott till leverantörer, upplupna ränteintäkter, momsfordran) |
+| **B9** | Kassa och bank |
+
+**Eget kapital:**
+| Post | Innehåll |
+|---|---|
+| **B10** | Eget kapital (= tillgångar − skulder) |
+
+**Skulder:**
+| Post | Innehåll |
+|---|---|
+| **B13** | Låneskulder (banklån, kreditavtal) |
+| **B14** | Skatteskulder (momsskuld, arbetsgivaravgifter, källskatt på lön) |
+| **B15** | Leverantörsskulder |
+| **B16** | Övriga skulder (förskott från kunder, upplupna räntekostnader, beslutade skadeståndsbetalningar) |
+
+### Resultaträkning struktur
+
+**Intäkter:**
+| Post | Innehåll |
+|---|---|
+| **R1** | Försäljning och utfört arbete samt övriga momspliktiga intäkter (konto 3000) |
+| **R2** | Momsfria intäkter (konto 3100, försäkringsersättningar, offentliga stöd, skadestånd) |
+| **R3** | Bil- och bostadsförmån mm (konto 3200) |
+| **R4** | Ränteintäkter mm (konto 8310, om sammanlagt > 5 000 kr) |
+
+**Kostnader:**
+| Post | Innehåll |
+|---|---|
+| **R5** | Varor, material och tjänster (konton 40–46 + 49) |
+| **R6** | Övriga externa kostnader (lokal, telefon, försäkringar, reklam, etc; konton 50–69 + 47) |
+| **R7** | Anställd personal (löner, sociala avgifter; konton 70–75) |
+| **R8** | Räntekostnader mm (konto 8410, om sammanlagt > 5 000 kr) |
+
+**Av- och nedskrivningar:**
+| Post | Innehåll |
+|---|---|
+| **R9** | Av- och nedskrivningar av byggnader och markanläggningar (konto 7820, 7821, 7824) |
+| **R10** | Av- och nedskrivningar av maskiner och inventarier och immateriella tillgångar (konto 7810, 7830) |
+
+**Resultat:**
+| Post | Innehåll |
+|---|---|
+| **R11** | Bokfört resultat (= R1+R2+R3+R4 − R5−R6−R7−R8−R9−R10) |
+
+R11 är direkt utgångspunkt för **NE-bilaga sida 1 R11**.
+
+### U-poster (upplysningar — informellt, inte bokförda)
+
+| Post | Innehåll |
+|---|---|
+| **U1** | Summan av alla periodiseringsfonder vid årets slut |
+| **U2** | Expansionsfond vid årets slut |
+| **U3** | Ersättningsfond vid årets slut |
+| **U4** | Insatsemissioner, skogskonto, skogsskadekonto, upphovsmannakonto, avbetalningsplan på skog och liknande |
+
+**Critical**: U1, U2, U4 are informationspunkter — NOT booked. Periodiseringsfond och expansionsfond för EF får (per BFNAR 2006:1) **inte** bokföras direkt mot resultatet → de hör hemma endast på NE-bilagan sid 2. Men du **får** bokföra dem på ett konto under eget kapital (e.g., 2080 Periodiseringsfonder) med ett **utjämningskonto** (2090) som motkonto, för att hålla reda på dem — pure information, no resultatpåverkan.
+
+U3 Ersättningsfond is **different**: ersättningsfond ÄR bokförd via resultaträkningen (med viss undantag för ersättningsfond för mark per BFNAR 2006:1 kommentar 9.2).
+
+## BAS 2018 Förenklat årsbokslut kontoplan — overview
+
+The K1-anpassade kontoplan har en mycket reducerat kontostruktur vs full BAS 2024. Key konton:
+
+### Tillgångar (1xxx)
+
+| Konto | Namn | B-post |
+|---|---|---|
+| 1000 | Immateriella anläggningstillgångar | B1 |
+| 1009 | Årets avskrivningar på immateriella anläggningstillgångar | B1 |
+| 1110 | Byggnader | B2 |
+| 1119 | Ackumulerade avskrivningar på byggnader | B2 |
+| 1130 | Mark | B3 |
+| 1150 | Markanläggningar | B2 |
+| 1159 | Ackumulerade avskrivningar på markanläggningar | B2 |
+| 1180 | Pågående nyanläggningar och förskott för byggnader och mark | B3 |
+| 1220 | Maskiner och inventarier | B4 |
+| 1221 | Årets nyanskaffning av maskiner och inventarier | B4 |
+| 1222 | Årets ersättning för maskiner och inventarier | B4 |
+| 1229 | Årets avskrivningar på maskiner och inventarier | B4 |
+| 1230 | Byggnads- och markinventarier | B4 |
+| 1240 | Bilar och andra transportmedel | B4 |
+| 1300 | Andelar | B5 |
+| 1400 | Lager | B6 |
+| 1500 | Kundfordringar | B7 |
+| 1600 | Övriga fordringar | B8 |
+| 1650 | Momsfordran | B8 |
+| 1700 | Förskott till leverantörer | B8 |
+| 1910 | Kassa | B9 |
+| 1920 | PlusGiro | B9 |
+| 1930 | Företagskonto/checkkonto/affärskonto | B9 |
+| 1940 | Övriga bankkonton | — |
+| 1970 | Särskilda bankkonton | B9 |
+
+### Eget kapital (2xxx)
+
+| Konto | Namn | B-post |
+|---|---|---|
+| 2010 | Eget kapital, delägare 1 | B10 |
+| 2011 | Egna varuuttag | B10 |
+| 2012 | Avräkning för skatter och avgifter (skattekonto) | B10 |
+| 2013 | Övriga egna uttag | B10 |
+| 2014 | Uttag förmåner | B10 |
+| 2017 | Egna insättningar | B10 |
+| 2019 | Årets resultat, delägare 1 | B10 |
+| 2020–2040 | Eget kapital, delägare 2–4 | B10 |
+| 2050 | Avsättning till expansionsfond | **U2** (information; ej bokfört avdrag) |
+| 2060 | Ersättningsfond | **U3** (bokfört) |
+| 2070 | Insatsemissioner, avbetalningsplan på skog, skogskonto, upphovsmannakonto | **U4** |
+| 2080 | Periodiseringsfonder | **U1** (information; ej bokfört avdrag) |
+| 2081–2089 | Periodiseringsfond olika år | **U1** |
+| 2090 | Utjämningskonto upplysningar 1–4 | (motkonto for U1/U2/U4) |
+
+### Skulder (2xxx forts.)
+
+| Konto | Namn | B-post |
+|---|---|---|
+| 2330 | Checkräkningskredit | B13 |
+| 2350 | Skulder till kreditinstitut | B13 |
+| 2390 | Övriga låneskulder | B13 |
+| 2440 | Leverantörsskulder | B15 |
+| 2610–2649 | Moms-konton (utgående 25%/12%/6%, ingående) | B14 |
+| 2650 | Redovisningskonto för moms | B14 |
+| 2660 | Särskilda punktskatter | B14 |
+| 2710 | Personalskatt | B14 |
+| 2730 | Lagstadgade sociala avgifter och särskild löneskatt | B14 |
+| 2900 | Övriga skulder (förutbetalda intäkter, upplupna räntekostnader, etc) | B16 |
+
+### Intäkter (3xxx)
+
+| Konto | Namn | R-post |
+|---|---|---|
+| 3000 | Försäljning och utfört arbete samt övriga momspliktiga intäkter | **R1** |
+| 3100 | Momsfria intäkter | **R2** |
+| 3200 | Bil- och bostadsförmån mm | **R3** |
+| 3500 | Fakturerade kostnader | **R1** |
+| 3700 | Lämnade rabatter, bonus etc | R1/R2 |
+| 3900 | Övriga rörelseintäkter | R1/R2 |
+| 3970 | Vinst vid avyttring av immateriella och materiella tillgångar | **R2** |
+| 3980 | Erhållna bidrag | **R2** |
+
+### Kostnader (4xxx–6xxx)
+
+| Konto | Namn | R-post |
+|---|---|---|
+| 4000 | Varor | R5 |
+| 4600 | Legoarbeten och underentreprenader | R5 |
+| 4700 | Erhållna rabatter, bonus etc | R6 |
+| 4900 | Förändring av lager | R5 |
+| 5000 | Lokalkostnader | R6 |
+| 5100 | Fastighetskostnader | R6 |
+| 5200 | Hyra av anläggningstillgångar | R6 |
+| 5400 | Förbrukningsinventarier och förbrukningsmaterial | R6 |
+| 5500 | Reparation och underhåll | R6 |
+| 5600–5620 | Kostnader för transportmedel | R6 |
+| 5700 | Frakter och transporter | R6 |
+| 5800 | Resekostnader | R6 |
+| 5900 | Reklam och PR | R6 |
+| 6000 | Övriga försäljningskostnader | R6 |
+| 6070 | Representation | R6 |
+| 6071 | Representation, avdragsgill | R6 |
+| 6072 | Representation, ej avdragsgill | R6 + NE sid 2 (justeringspost R16) |
+| 6100 | Kontorsmateriel och trycksaker | R6 |
+| 6200 | Tele och post | R6 |
+| 6300/6310 | Företagsförsäkringar och övriga riskkostnader | R6 |
+| 6500 | Övriga externa tjänster | R6 |
+| 6800 | Inhyrd personal | R6 |
+| 6900/6980 | Övriga kostnader, föreningsavgifter | R6 |
+
+### Personalkostnader (7xxx)
+
+| Konto | Namn | R-post |
+|---|---|---|
+| 7000 | BAS-konton Löner till anställda | R7 |
+| 7300 | Kostnadsersättningar och förmåner | R7 |
+| 7400 | Pensionskostnader | R7 |
+| 7500 | Sociala och andra avgifter enligt lag och avtal | R7 |
+| 7810 | Avskrivning på immateriella anläggningstillgångar | R10 |
+| 7820/7821/7824 | Avskrivning byggnader/markanläggningar | R9 |
+| 7830 | Avskrivning maskiner och inventarier | R10 |
+
+### Finansiella poster (8xxx)
+
+| Konto | Namn | R-post |
+|---|---|---|
+| 8310 | Ränteintäkter och utdelningar | R4 |
+| 8410 | Räntekostnader för skulder | R8 |
+| 8999 | Årets resultat (motkonto) | — |
+| 2019 | Årets resultat (egen kapital sida) | — |
+
+## Värderingsregler — K1 skiljer sig från K2/K3
+
+Tanken med K1: **så få justeringar som möjligt mellan redovisat resultat och skattemässigt resultat** — alltså K1-värderingar följer skatteregler.
+
+### Inventarier
+
+- Skattemässig värdering: **räkenskapsenlig avskrivning huvudregel 30%** eller **kompletteringsregel 20%** (samma som AB)
+- I förteckning över anläggningstillgångar dokumenteras: datum, tillgång, anskaffningsvärde, livslängd
+
+### Räkenskapsenlig avskrivning huvudregel — 30%
+
+- Avskrivningsunderlag = bokfört värde IB + årets inköp − årets försäljningar
+- Avskrivning max **30% av avskrivningsunderlaget**
+- Tillgångar tas upp till lägst **70% av avskrivningsunderlaget**
+
+### Räkenskapsenlig avskrivning kompletteringsregel — 20%
+
+- Tillgångar får tas upp till lägst:
+  - 80% × inköp under räkenskapsåret
+  - 60% × inköp under året före räkenskapsåret
+  - 40% × inköp under andra året före räkenskapsåret
+  - 20% × inköp under tredje året före räkenskapsåret
+- I praktiken: 20% avskrivning per år, så att tillgången är helt avskriven efter 5 år
+
+Each year: räkna ut lägsta värdet enligt huvudregel + lägsta enligt kompletteringsregel → välj lägsta → årets avskrivning = avskrivningsunderlag − valda värdet.
+
+### Förbrukningsinventarier — direktavdrag
+
+- Korttidsinventarier (livslängd ≤ 3 år) → direktavdrag i sin helhet
+- Inventarier av mindre värde (anskaffningsvärde < halvt prisbasbelopp; ≈ 29 400 kr 2025 + moms) → direktavdrag möjligt
+
+### Lagervärdering
+
+- Huvudregel: lägsta värdets princip (LVP) — det lägre av anskaffningsvärde och nettoförsäljningsvärde
+- FIFO för värdering av identiska partier
+- **97%-regeln** (3% schablonmässigt inkuransavdrag) tillåts i K1
+- **K1 specifik förenkling**: lager < 5 000 kr **behöver inte alls tas upp** (PDF ened sid 240 punkt 3: "varuförändring bokförs (endast lager överstigande 5 000 kr måste tas upp som tillgång)")
+
+### Skulder
+
+- Skulder som inte hade behövts om bokföringen följde faktureringsmetoden → **får utelämnas om < 5 000 kr**
+- Räntekostnader och förskott från kunder < 5 000 kr → behöver inte periodiseras
+
+### Avskrivning byggnader
+
+- Skattemässig avskrivningsplan följs (vanligen 2–4% per år för bostads-, hyres-, industrifastigheter)
+- För småhus 2% per år är typiskt
+
+### Skogskonto / skogsskadekonto / upphovsmannakonto
+
+- Medlen tas upp till **halva beloppet** för räntefördelningens kapitalunderlag (latent skatt)
+- I förenklat årsbokslut: redovisas som information **U4**, inte som tillgång (eller delvis)
+
+## NE-bilaga mapping (the critical bridge)
+
+The whole point of the förenklade årsbokslutet is to feed directly into NE-bilagan utan extra arbete:
+
+| Förenklat årsbokslut | → | NE-bilaga ruta |
+|---|---|---|
+| B1 Immateriella anläggningstillgångar | → | (info ruta 5–6 om anläggningstillgångar) |
+| B2-B4 Övriga anläggningstillgångar | → | (info ruta 5–6) |
+| B6 Varulager | → | (info ruta 5) |
+| B7 Kundfordringar | → | (info ruta 5) |
+| B9 Kassa och bank | → | (info ruta 5) |
+| B10 Eget kapital | → | (info ruta 6) |
+| B13-B16 Skulder | → | (info ruta 6) |
+| R11 Bokfört resultat | → | NE **R11** |
+| R12-R26 (in deklarationsbilden) | Skattemässiga justeringar (ej avdragsgill rep, ränta osv) | NE R12–R26 |
+| U1 Periodiseringsfonder | → | NE **R29 (återföring)** / **R35 (avsättning)** |
+| U2 Expansionsfond | → | NE **R36 (återföring i NV)** / **R37 (ökning)** |
+| U3 Ersättningsfond | → | (bokförd avsättning, ingen separat NE-ruta) |
+| (Räntefördelning) | → | NE **R30** |
+| (Eget egenavgifter schablonavdrag) | → | NE **R39, R40, R43** |
+| Aktiv/passiv-kryssruta | → | NE sid 1 |
+| Slutligt R47/R48 (aktiv) eller R49/R50 (passiv) | → | INK1 sid 2 ruta 10.1–10.4 |
+
+## Värderingsregler vid avveckling (vid sista räkenskapsåret)
+
+Vid företagets nedläggning används samma värderingsregler som i löpande verksamhet, men:
+- All P-fond och expansionsfond måste återföras till beskattning
+- Sparat fördelningsbelopp (positiv räntefördelning) får användas mot återföringen
+- Ackumulerad inkomst-beräkning kan begäras (se [[ackumulerad-inkomst]] in `swedish-ef-skatteplanering`)
+
+## Förteckning över anläggningstillgångar
+
+Required by BFNAR 2006:1 kap 6:
+
+Förteckning ska innehålla **per tillgång**:
+- Datum för anskaffning
+- Tillgångens benämning
+- Anskaffningsvärde (totalt inkl ev. moms om köpet ej är momspliktig)
+- Beräknad livslängd (för bedömning av avskrivningstid)
+
+Förenklingsregel: om endast fåtal tillgångar finns, behöver inte separate förteckning föras — det räcker om uppgifter framgår av den löpande bokföringen (kopior av fakturor i en pärm).
+
+Praktisk implementering: skriva på fakturakopian hur länge tillgången beräknas vara till nytta (e.g., "10 år" på en bil-faktura).
+
+Vid utrangering eller försäljning ska tillgången **strykas** från förteckningen.
+
+## Arkivering
+
+All räkenskapsinformation (verifikationer, det förenklade årsbokslutet, lagervärdering, anläggningsförteckning, anläggningsavtal, ansvarsförbindelser) ska arkiveras **7 år** efter räkenskapsårets utgång enligt BFL 7 kap.
+
+Format: pappersfakturor → behåll i original i pärm; elektroniska underlag → arkiveras elektroniskt (eller papper om inkommit på papper). Skannad pappersfaktura kan arkiveras digitalt OM originalet behålls 3 år extra.
+
+## Praktikfall — Stina Svensson (PDF distilled)
+
+This is the worked example from ened.pdf kapitel "Praktikfall". Distilled here as illustration:
+
+**Stina** driver en EF (måleri):
+- Industribyggnad + mark
+- Bokför enligt **kontantmetoden**, redovisar moms en gång per år
+- Räkenskapsår 2018 (jan-dec)
+- Betalar månatligen 20 000 kr F-skatt → 240 000 kr för hela året
+
+### Arbetsgång vid bokslut
+
+1. **Avstämning** — kontrollera att alla betalningar är bokförda; bekräfta saldon mot bank, skattekonto, kassa
+2. **Avskrivningar byggnader** (B2): industrifastigheten avskrivs med 4% av 625 000 kr = **25 000 kr/år**
+3. **Avskrivningar inventarier** (B4): huvudregeln 30% av (IB 145 406 − sålt 40 000) = 30% × 105 406 = 31 622 kr
+4. **Lagervärdering** (B6): inventering 31 dec, värdera enligt FIFO; 97% × 31 900 = 30 943 kr
+5. **Kundfordringar** (B7): bokföra föregående års (avbokas) och beräkna årets 52 000 kr
+6. **Övriga fordringar** (B8): förskott till leverantörer (förhöjd leasingavgift), 42 000 kr
+7. **Kassa och bank** (B9): 79 121 kr
+8. **Låneskulder** (B13): fastighetslån 487 220 kr
+9. **Leverantörsskulder** (B15): 31 775 kr (inkl moms 7 156 kr)
+10. **Övriga skulder** (B16): förskott från kund 12 000 kr
+11. **Skatteskuld** (B14): moms 100 721 kr
+12. **Boka årets resultat**: 322 891 kr → 8999 Debit / 2019 Credit
+13. **Fyll i förenklat årsbokslut** med U1 = 80 000 kr P-fond (informationspost)
+
+### Slutgiltiga siffror
+- Tillgångar summa: 852 848 kr
+- Skulder + eget kapital: 852 848 kr
+- Årets resultat (R11): **322 891 kr**
+
+Detta R11 förs direkt till NE-bilaga ruta R11. Sedan görs skattemässiga justeringar (R12-R26), räntefördelning (R30), periodiseringsfond (R29/R35), expansionsfond (R36/R37), och slutligen schablonavdrag egenavgifter (R43).
+
+Stina's situation: hon har bokförd P-fond 80 000 kr (i U1) — DETTA ÄR ENDAST UPPLYSNING, inte ett avdrag i resultaträkningen. Det skattemässiga avdraget för P-fond görs i NE-bilagan ruta R35.
+
+## Common pitfalls (specifika för K1)
+
+1. **Bokföra P-fond / expansionsfond som kostnad i resultaträkningen** — INTE tillåtet i K1 → avdraget blir ogiltigt
+2. **Använda brutet räkenskapsår** — INTE tillåtet för enskild näringsidkare
+3. **Räkna fel på lager < 5 000 kr** — får utelämnas (men måste konsekvent: lager 4 999 kr utelämnas; 5 001 kr tas upp)
+4. **Glömma förskott från kunder > 5 000 kr** — ska redovisas som skuld (B16), minskar R1 årets försäljning
+5. **Förenkla bort relevanta verifikationer** — verifikationerna är fortfarande huvudbevis enligt BFL
+6. **Använda K1 trots > 3 MSEK omsättning** — INTE tillåtet
+7. **Glömma U1-U4 upplysningar** — formell compliance issue
+8. **Felaktig värdering av skogskonto / upphovsmannakonto** — ska tas upp till halva beloppet (latent skatt 50%)
+9. **Glömma att åtgärda ärvda fel** — om föregående års bokslut hade fel, kan man behöva ändra IB i nuvarande år
+10. **Periodisera räntor < 5 000 kr** — INTE krävt i K1 (förenkling), men för icke-K1-företag är det krav
+
+## When K1 is *not* enough — switch to fullt årsbokslut
+
+K1 räcker oftast, men byt till **fullt årsbokslut** (BFNAR 2017:3) när:
+- Omsättning överstiger 3 MSEK
+- Du behöver kassaflödesanalys för bankfinansiering
+- Du driver gemensamt med en delägare > 3 MSEK (samtliga deklarerar fullt årsbokslut)
+- Skattemässiga rapporteringsbehov överstiger K1:s förenklade format
+
+Fullt årsbokslut innehåller:
+- Resultaträkning + balansräkning med fullständiga uppställningar
+- Tilläggsupplysningar
+- (Optional) kassaflödesanalys
+- Specifikationsförteckningar
+
+## Implementation checklist för software
+
+If you build bokföringssoftware targeted at EF:
+- [ ] Detect omsättning > 3 MSEK → require switch to fullt årsbokslut
+- [ ] Force K1-kontoplan struktur när K1 valt
+- [ ] Block bokföring av P-fond/expansionsfond mot resultatkonto
+- [ ] Allow informationsbokföring 2080/2050/2070 mot 2090 utjämningskonto
+- [ ] Generate förenklat årsbokslut layout (SKV 2150 web pattern)
+- [ ] Generate NE-bilaga med exakt mappning från B/R/U-poster
+- [ ] Track räkenskapsmaterial 7 år
+- [ ] Track anläggningsförteckning (datum, tillgång, anskaffningsvärde, livslängd)
+- [ ] Force kalenderår räkenskapsår
+- [ ] Support kontantmetoden + faktureringsmetoden
+- [ ] Allow utelämning av < 5 000 kr fordringar/skulder per BFNAR 2006:1
+- [ ] Apply 97% schablonavdrag för inkurans på lager
+- [ ] Apply huvudregel/kompletteringsregel for avskrivning, choose lower automatic
+- [ ] Surface 80 000 kr halv-PBB cap för förbrukningsinventarier (29 400 kr 2025)
+
+## Out of scope
+
+- AB-årsredovisning (use `swedish-financial-reporting`)
+- Detailed NE-bilaga fält-by-fält (covered separately)
+- INK1 huvudblankett (general personal tax form)
+- Skatteplanerings-instrument för EF (use `swedish-ef-skatteplanering`)
+- Momsdeklaration mekanik (use `swedish-vat`)
+
+## Legal sources
+
+- **BFL 1999:1078** — primary bokföringslagstiftning, especially 4 kap (omfattning), 5 kap (löpande bokföring), 6 kap (årsbokslut), 7 kap (arkivering)
+- **BFNAR 2006:1** — K1, det förenklade årsbokslutet för enskild näringsidkare
+- **BFNAR 2017:3** — fullt årsbokslut för icke-AB (the K2-EF equivalent)
+- **SKV 2150** — Skatteverket's Förenklat årsbokslut blankett
+- **SKV 2161** — NE-bilaga (näringsbilaga för enskild näringsverksamhet)
+- **BAS 2018 Förenklat årsbokslut kontoplan** — published by BAS-kontogruppen

--- a/.claude/skills/swedish-year-end-closing/references/k1-forenklat-arsbokslut.md
+++ b/.claude/skills/swedish-year-end-closing/references/k1-forenklat-arsbokslut.md
@@ -26,7 +26,7 @@ If the same person runs multiple verksamheter:
 
 If multiple personer arbetar gemensamt i ett enkelt bolag:
 - Track-aggregeras per delägare → each delägare's share räknas mot 3 MSEK
-- If en delägares andel > 3 MSEK, samme delägare måste lämna fullt årsbokslut — och om så är fallet, alla delägare ska lämna fullt årsbokslut för den gemensamma verksamheten (PDF: "Följer man reglerna om förenklat årsbokslut i en verksamhet måste samma regler också tillämpas för de övriga verksamheterna")
+- If en delägares andel > 3 MSEK, samme delägare måste lämna fullt årsbokslut — och om så är fallet, alla delägare ska lämna fullt årsbokslut för den gemensamma verksamheten. En näringsidkare som tillämpar förenklat årsbokslut i en verksamhet ska använda samma regelverk för sina övriga verksamheter — man får inte blanda förenklat och fullständigt över olika delverksamheter.
 
 ## Räkenskapsåret
 
@@ -303,7 +303,7 @@ Each year: räkna ut lägsta värdet enligt huvudregel + lägsta enligt komplett
 - Huvudregel: lägsta värdets princip (LVP) — det lägre av anskaffningsvärde och nettoförsäljningsvärde
 - FIFO för värdering av identiska partier
 - **97%-regeln** (3% schablonmässigt inkuransavdrag) tillåts i K1
-- **K1 specifik förenkling**: lager < 5 000 kr **behöver inte alls tas upp** (PDF ened sid 240 punkt 3: "varuförändring bokförs (endast lager överstigande 5 000 kr måste tas upp som tillgång)")
+- **K1 specifik förenkling**: lager < 5 000 kr **behöver inte alls tas upp** som tillgång — varuförändringen bokförs men endast lager över 5 000 kr balansredovisas
 
 ### Skulder
 
@@ -317,8 +317,8 @@ Each year: räkna ut lägsta värdet enligt huvudregel + lägsta enligt komplett
 
 ### Skogskonto / skogsskadekonto / upphovsmannakonto
 
-- Medlen tas upp till **halva beloppet** för räntefördelningens kapitalunderlag (latent skatt)
-- I förenklat årsbokslut: redovisas som information **U4**, inte som tillgång (eller delvis)
+- I förenklat årsbokslut: **kontosaldot bokförs i sin helhet i B9 (Kassa och bank)** — pengarna tillhör företaget och ska redovisas som tillgång. Dessutom upplyses kontot i ruta **U4** (Övriga upplysningar) med beskrivning av kontotyp och latent skatteskuld.
+- För **räntefördelningens kapitalunderlag** tas däremot bara **halva beloppet** av skogskonto/skogsskadekonto/upphovsmannakonto med (latent skatt elimineras).
 
 ## NE-bilaga mapping (the critical bridge)
 
@@ -335,10 +335,11 @@ The whole point of the förenklade årsbokslutet is to feed directly into NE-bil
 | B13-B16 Skulder | → | (info ruta 6) |
 | R11 Bokfört resultat | → | NE **R11** |
 | R12-R26 (in deklarationsbilden) | Skattemässiga justeringar (ej avdragsgill rep, ränta osv) | NE R12–R26 |
-| U1 Periodiseringsfonder | → | NE **R29 (återföring)** / **R35 (avsättning)** |
-| U2 Expansionsfond | → | NE **R36 (återföring i NV)** / **R37 (ökning)** |
-| U3 Ersättningsfond | → | (bokförd avsättning, ingen separat NE-ruta) |
-| (Räntefördelning) | → | NE **R30** |
+| U1 Periodiseringsfonder | → | NE **R32 (återföring)** / **R34 (avsättning)** |
+| U2 Expansionsfond | → | NE **R36 (återföring)** → INK1 p.12.1 / **R37 (ökning)** → INK1 p.12.2 |
+| U3 Ersättningsfond | → | (bokförd avsättning via resultaträkningen, ingen separat NE-ruta — påverkar R11) |
+| (Räntefördelning positiv) | → | NE **R30** → INK1 p.11.1 (inkomst av kapital) |
+| (Räntefördelning negativ) | → | NE **R31** → INK1 p.11.2 (avdrag i kapital) |
 | (Eget egenavgifter schablonavdrag) | → | NE **R39, R40, R43** |
 | Aktiv/passiv-kryssruta | → | NE sid 1 |
 | Slutligt R47/R48 (aktiv) eller R49/R50 (passiv) | → | INK1 sid 2 ruta 10.1–10.4 |
@@ -370,42 +371,36 @@ Vid utrangering eller försäljning ska tillgången **strykas** från förteckni
 
 All räkenskapsinformation (verifikationer, det förenklade årsbokslutet, lagervärdering, anläggningsförteckning, anläggningsavtal, ansvarsförbindelser) ska arkiveras **7 år** efter räkenskapsårets utgång enligt BFL 7 kap.
 
-Format: pappersfakturor → behåll i original i pärm; elektroniska underlag → arkiveras elektroniskt (eller papper om inkommit på papper). Skannad pappersfaktura kan arkiveras digitalt OM originalet behålls 3 år extra.
+Format: pappersfakturor → behåll i original i pärm; elektroniska underlag → arkiveras elektroniskt (eller papper om inkommit på papper).
 
-## Praktikfall — Stina Svensson (PDF distilled)
+**BFL-ändring 2024-07-01:** kravet att behålla pappersoriginal i 3 år efter scanning **är borttaget**. Pappersoriginal får förstöras direkt efter att räkenskapsinformationen överförts till ett annat format, förutsatt att överföringen är tillförlitlig och den digitala kopian uppfyller arkiveringskraven. 7-årsregeln gäller fortfarande för den lagrade räkenskapsinformationen.
 
-This is the worked example from ened.pdf kapitel "Praktikfall". Distilled here as illustration:
+## Bokslutsprocess — checklista per K1-fält
 
-**Stina** driver en EF (måleri):
-- Industribyggnad + mark
-- Bokför enligt **kontantmetoden**, redovisar moms en gång per år
-- Räkenskapsår 2018 (jan-dec)
-- Betalar månatligen 20 000 kr F-skatt → 240 000 kr för hela året
+Bokslutssekvens för en EF som upprättar förenklat årsbokslut. Varje steg motsvarar en post i förenklat årsbokslut och dess bokföringsmotsvarighet.
 
-### Arbetsgång vid bokslut
+| # | Operation | Förenklat årsbokslut-fält |
+|---|---|---|
+| 1 | Avstämning bank/kassa/skattekonto vs bokföring (innan B-poster) | — |
+| 2 | Avskrivning byggnader (4 % standard för industri-/näringsfastighet — kontrollera SKV A 2005:5 för byggnadstyp) | B2 |
+| 3 | Avskrivning inventarier — huvudregeln 30 % declining på (IB + årets inköp − årets försäljningar) eller kompletteringsregeln 20 % straight-line. Använd det som ger lägst restvärde. | B4 |
+| 4 | Lagervärdering — fysisk inventering 31 dec, 97 % av anskaffningsvärde (3 %-schablonavdrag) eller 85 % för djurlager. Lager < halvt PBB får utelämnas (BFNAR 2025:1) | B6 |
+| 5 | Kundfordringar — avboka fjolårets, boka årets per saldolista 31 dec | B7 |
+| 6 | Övriga fordringar — förhöjd leasingavgift, förskott till leverantör | B8 |
+| 7 | Kassa och bank — saldon 31 dec inklusive skogskonto till **fullt belopp** (se separat sektion) | B9 |
+| 8 | Låneskulder | B13 |
+| 9 | Skatteskulder — moms, AGI-skuld | B14 |
+| 10 | Leverantörsskulder inkl. moms | B15 |
+| 11 | Övriga skulder — förskott från kund > halvt PBB | B16 |
+| 12 | Boka årets resultat (8999 debet / 2019 kredit för EF) | R11 |
+| 13 | Fyll i U1 (P-fond), U2 (expansionsfond), U3 (ersättningsfond), U4 (skogskonto/upphovsmannakonto/betalningsplan) | U1-U4 |
+| 14 | För R11 till NE-bilaga, fortsätt med skattemässiga justeringar R12-R26, RF R30/R31, P-fond R32/R34, expansionsfond R36/R37, schablonavdrag R43 | (NE forts.) |
 
-1. **Avstämning** — kontrollera att alla betalningar är bokförda; bekräfta saldon mot bank, skattekonto, kassa
-2. **Avskrivningar byggnader** (B2): industrifastigheten avskrivs med 4% av 625 000 kr = **25 000 kr/år**
-3. **Avskrivningar inventarier** (B4): huvudregeln 30% av (IB 145 406 − sålt 40 000) = 30% × 105 406 = 31 622 kr
-4. **Lagervärdering** (B6): inventering 31 dec, värdera enligt FIFO; 97% × 31 900 = 30 943 kr
-5. **Kundfordringar** (B7): bokföra föregående års (avbokas) och beräkna årets 52 000 kr
-6. **Övriga fordringar** (B8): förskott till leverantörer (förhöjd leasingavgift), 42 000 kr
-7. **Kassa och bank** (B9): 79 121 kr
-8. **Låneskulder** (B13): fastighetslån 487 220 kr
-9. **Leverantörsskulder** (B15): 31 775 kr (inkl moms 7 156 kr)
-10. **Övriga skulder** (B16): förskott från kund 12 000 kr
-11. **Skatteskuld** (B14): moms 100 721 kr
-12. **Boka årets resultat**: 322 891 kr → 8999 Debit / 2019 Credit
-13. **Fyll i förenklat årsbokslut** med U1 = 80 000 kr P-fond (informationspost)
-
-### Slutgiltiga siffror
-- Tillgångar summa: 852 848 kr
-- Skulder + eget kapital: 852 848 kr
-- Årets resultat (R11): **322 891 kr**
-
-Detta R11 förs direkt till NE-bilaga ruta R11. Sedan görs skattemässiga justeringar (R12-R26), räntefördelning (R30), periodiseringsfond (R29/R35), expansionsfond (R36/R37), och slutligen schablonavdrag egenavgifter (R43).
-
-Stina's situation: hon har bokförd P-fond 80 000 kr (i U1) — DETTA ÄR ENDAST UPPLYSNING, inte ett avdrag i resultaträkningen. Det skattemässiga avdraget för P-fond görs i NE-bilagan ruta R35.
+Kritiska invarianter att kontrollera efter steg 14:
+- Σ tillgångar = Σ skulder + eget kapital (balansidentitet)
+- U1-U4 är **upplysningar**, INTE bokföringsposter mot resultatet
+- R11 i NE = R11 i förenklat årsbokslut (samma siffra)
+- P-fond i U1 är endast information — avdraget görs på NE-ruta R34, INTE i resultaträkningen
 
 ## Common pitfalls (specifika för K1)
 
@@ -450,7 +445,7 @@ If you build bokföringssoftware targeted at EF:
 - [ ] Allow utelämning av < 5 000 kr fordringar/skulder per BFNAR 2006:1
 - [ ] Apply 97% schablonavdrag för inkurans på lager
 - [ ] Apply huvudregel/kompletteringsregel for avskrivning, choose lower automatic
-- [ ] Surface 80 000 kr halv-PBB cap för förbrukningsinventarier (29 400 kr 2025)
+- [ ] Surface halv-PBB-cap för förbrukningsinventarier (29 400 kr 2025 / 29 600 kr 2026; gräns höjd från 5 000 kr fr.o.m. 2025 via prop. 2024/25:1)
 
 ## Out of scope
 


### PR DESCRIPTION
## Summary

En ny skill, `swedish-ef-skatteplanering`, för skatteplanering i enskild firma. Det här är *inte* K1-bokslutsmekanik — det är vad som händer efteråt: ska jag räntefördela, avsätta P-fond, anställa min make, ombilda till AB? Innehållet är till för att läsas av en LLM (decision tables, pseudokod, NE-rutor) och inte av en människa rakt igenom.

Branchen: 1 SKILL.md + 9 referensfiler, en kompletterande K1-referens i `swedish-year-end-closing/`, en chore-commit i `swedish-tax-planning/` som klargör scope, och en fix-commit som drar allt i linje med 2025-2026 års regler.

## What's covered

Planeringsverktygen:
- Aktiv vs passiv näringsverksamhet — 500-600h-testet, kvittning, JSA
- Räntefördelning — när det lönar sig, kapitalunderlag, sparat fördelningsbelopp
- Periodiseringsfond + expansionsfond — interaktion, NE-ordning, U1/U2
- Ersättningsfond — fyra fondtyper, 30 % straffavgift, ny 10-årsregel
- Inkomstuppdelning i familjen — medhjälpande make, lön till barn, F-skatt
- Kvittning av underskott — 5-årsregel, 70 % slutligt underskott, kulturarbetare
- Ackumulerad inkomst (IL 66 kap)
- Egenavgifter / SGI / PGI / JSA — interaktionsmatris för alla dispositioner
- EF vs AB — break-even-scenarier

2025-2026 reformer som finns inarbetade:
- RF-reformen 2025 (prop. 2024/25:1): +50 001-tröskeln slopad, negativ höjd till -500 000 kr
- JSA-höjningar 2022-2026 (senast prop. 2025/26:32): 47 300 kr 2025 / 52 400 kr 2026
- Halva PBB som inventariegräns (BFNAR 2025:1)
- SGI- och föräldrapenning-tak 10 PBB (höjdes från 7,5 PBB 2018)
- Ersättningsfond 3 → 10 år (Skogsskattereformen, prop. 2025/26:69, ikraft 2026-04-01). 3-årsregeln är kvar med övergångsregel-etikett för avsättningar gjorda före brytdatumet.
- Expansionsfond-multiplikator 125,94 % vid 20,6 % expansionsfondsskatt. Äldre källor (22 % bolagsskatt) ger 128,21 %.
- Riktåldern höjs successivt — 66 år 2025, 67 år 2026 för full egenavgift

Citations: IL 1999:1229 kap 13, 14, 18, 30, 31, 33, 34, 60, 62, 66; SAL 2000:980; SLF-lagen 1990:659; BFL 1999:1078; BFNAR 2006:1 + BFNAR 2025:1; SOU 2020:50 (delvis genomförd).

Praktiska mappningar: NE-rutor R11, R24, R32-R37, R39-R45, R47-R50; INK1 8.4 och 14.1; U1/U2/U3-upplysningar.

## Files

```
.claude/skills/swedish-ef-skatteplanering/
  SKILL.md
  references/
    aktiv-passiv-naringsverksamhet.md
    rantefordelning-planning.md
    periodiseringsfond-expansionsfond-ef.md
    ersattningsfond.md
    inkomstuppdelning-familj.md
    kvittning-underskott.md
    ackumulerad-inkomst.md
    egenavgifter-sgi-pgi-jsa.md
    ef-vs-ab-breakeven.md

.claude/skills/swedish-year-end-closing/
  SKILL.md                              (K1-rad i triggertabellen)
  references/k1-forenklat-arsbokslut.md (ny K1-referens)

.claude/skills/swedish-tax-planning/
  SKILL.md                              (klargjord AB-scope + cross-ref till EF)
```

## Where I'd value another pair of eyes

Spots jag inte är helt säker på och gärna får en check på:

1. NE-rutornas numrering. Jag har R11 bokfört resultat, R32/R34 P-fond, R36/R37 expansionsfond, R45 allmänt avdrag — mot nuvarande SKV 2161, inte pre-2018-layouten.
2. Räntefördelningsräntorna. SLR 30 november föregående år, värden 1,96 % (2025) och 2,55 % (2026), positiv rate SLR+6, negativ SLR+1.
3. Ersättningsfond 3 → 10 år. Jag har antagit att förlängningen gäller alla fyra fondtyper, inte bara skogsbruk — verifiera mot prop. 2025/26:69.
4. Pensionärsåldersgränsen — 66 år 2025, 67 år 2026 för full egenavgift.
5. Expansionsfond 125,94 %. Räknat som 100/79,4. Äldre källor på 22 % bolagsskatt ger 128,21 %.
6. JSA-beloppen — 47 300 kr 2025 / 52 400 kr 2026 enligt prop. 2025/26:32.

## Test plan

- [ ] Spot-check siffervärden mot Skatteverkets Belopp och procent för 2025/2026
- [ ] Verifiera IL-paragrafer i decision-tabellerna
- [ ] Kör ett verkligt EF-scenario (t.ex. konsult med makar + barn 16+) genom en LLM med skillen laddad
- [ ] Manuell scan efter verbatim-citat är gjord — gärna ett par till ögon på det